### PR TITLE
Audit the dependencies

### DIFF
--- a/DEPENDENCY_AUDIT_REPORT.md
+++ b/DEPENDENCY_AUDIT_REPORT.md
@@ -1,0 +1,196 @@
+# Dependency Audit Report
+**Date:** 2026-01-20
+**Project:** jpaladini-website
+**Package Manager:** npm
+
+## Executive Summary
+
+✅ **Security Status:** No vulnerabilities detected
+✅ **Bloat Assessment:** Minimal and well-optimized
+⚠️ **Update Status:** Minor updates recommended
+
+The project maintains a clean, minimal dependency footprint with only 3 direct dependencies. All packages are up-to-date within their compatible version ranges.
+
+---
+
+## 1. Security Vulnerabilities
+
+**Status:** ✅ PASS
+
+```
+Total vulnerabilities: 0
+- Critical: 0
+- High: 0
+- Moderate: 0
+- Low: 0
+- Info: 0
+```
+
+**Recommendation:** No action required. Continue monitoring with regular `npm audit` checks.
+
+---
+
+## 2. Outdated Packages
+
+### Current Dependencies
+
+| Package | Current (package.json) | Installed | Latest | Status |
+|---------|----------------------|-----------|--------|--------|
+| astro | ^5.10.0 | 5.16.11 | 5.16.11 | ⚠️ Update recommended |
+| @astrojs/tailwind | ^6.0.2 | 6.0.2 | 6.0.2 | ✅ Up to date |
+| tailwindcss | ^3.4.17 | 3.4.19 | 3.4.19 (v3) / 4.1.18 (v4) | ⚠️ Minor update / See note |
+
+### Update Recommendations
+
+#### 1. Astro (Recommended)
+**Action:** Update package.json from `^5.10.0` to `^5.16.11`
+
+The installed version (5.16.11) is already the latest, but package.json references an older version. Update for consistency:
+
+```json
+"astro": "^5.16.11"
+```
+
+**Benefits:**
+- Bug fixes and performance improvements from 5.10.0 → 5.16.11
+- Better compatibility with latest ecosystem packages
+
+#### 2. Tailwind CSS (Minor Update)
+**Action:** Update package.json from `^3.4.17` to `^3.4.19`
+
+```json
+"tailwindcss": "^3.4.19"
+```
+
+**Benefits:**
+- Latest v3.x bug fixes and optimizations
+- Maintains full compatibility with @astrojs/tailwind
+
+#### 3. Tailwind CSS v4 (Future Consideration)
+**Status:** ❌ Not Compatible
+
+Tailwind CSS v4.1.18 is available but **cannot be used** with current @astrojs/tailwind integration.
+
+**Blocker:** `@astrojs/tailwind@6.0.2` requires `tailwindcss: ^3.0.24` (peer dependency)
+
+**Recommendation:** Monitor @astrojs/tailwind releases for v4 support. When available, evaluate the breaking changes before upgrading.
+
+---
+
+## 3. Dependency Bloat Analysis
+
+### Size Breakdown
+
+**Total node_modules size:** 149 MB
+**Total packages:** 350 (340 production, 0 dev, 81 optional)
+
+### Largest Dependencies
+
+| Package | Size | Justification |
+|---------|------|--------------|
+| @img | 33 MB | Image optimization (Astro built-in) |
+| typescript | 23 MB | TypeScript support (Astro dependency) |
+| @shikijs | 11 MB | Syntax highlighting (Astro dependency) |
+| @esbuild | 9.9 MB | Build tooling (Astro dependency) |
+| tailwindcss | 5.6 MB | Direct dependency - CSS framework |
+| @astrojs | 5.2 MB | Astro core packages |
+| @babel | 4.8 MB | JavaScript transpilation (build dependency) |
+| @rollup | 4.1 MB | Module bundler (Astro dependency) |
+
+### Bloat Assessment: ✅ MINIMAL
+
+**Verdict:** All large packages are essential dependencies for Astro's core functionality:
+- **Image processing** (@img): Required for Astro's built-in image optimization
+- **Build tools** (esbuild, rollup, babel): Required for development and production builds
+- **Syntax highlighting** (@shikijs): Required for Astro's code syntax highlighting
+- **TypeScript** (typescript): Required for Astro's TypeScript support
+
+**No unnecessary or redundant packages detected.**
+
+### Recommendations
+
+1. **No removals needed** - All dependencies are actively used
+2. **Consider devDependencies split** - Currently all packages are in `dependencies`. This is acceptable for a static site but could be optimized:
+   - Keep: `astro`, `@astrojs/tailwind`, `tailwindcss`
+   - All build tools are already automatically handled by Astro
+
+3. **Project structure is optimal** - Only 3 direct dependencies shows excellent dependency hygiene
+
+---
+
+## 4. Additional Observations
+
+### Positive Findings
+
+✅ **Minimal dependency footprint** - Only 3 direct dependencies
+✅ **No security vulnerabilities** - Clean audit
+✅ **Modern package versions** - All packages are recent and well-maintained
+✅ **No dev/prod mixing** - Clear dependency purpose
+✅ **Proper peer dependencies** - All peer dependency requirements satisfied
+✅ **Active maintenance** - All packages have recent releases
+
+### Environmental Notes
+
+- **npm version**: 10.9.4 (upgrade to 11.7.0 available but not required)
+- **Node modules cache**: Clean and optimized
+- **Lock file**: package-lock.json present and up-to-date
+
+---
+
+## 5. Recommended Actions
+
+### Immediate Actions (Low Risk)
+
+1. **Update package.json** to reflect installed versions:
+```json
+{
+  "dependencies": {
+    "@astrojs/tailwind": "^6.0.2",
+    "astro": "^5.16.11",
+    "tailwindcss": "^3.4.19"
+  }
+}
+```
+
+2. **Verify build** after updates:
+```bash
+npm run build
+```
+
+### Future Monitoring
+
+1. **Weekly:** Check `npm outdated` for new releases
+2. **Monthly:** Run `npm audit` for security vulnerabilities
+3. **Quarterly:** Review dependency tree for new optimization opportunities
+4. **Watch for:** @astrojs/tailwind support for Tailwind CSS v4
+
+### Optional Enhancements
+
+1. **Add npm scripts** for maintenance:
+```json
+"scripts": {
+  "dev": "astro dev",
+  "build": "astro build",
+  "preview": "astro preview",
+  "audit": "npm audit",
+  "outdated": "npm outdated"
+}
+```
+
+2. **Consider GitHub Dependabot** for automated dependency updates
+
+---
+
+## 6. Conclusion
+
+**Overall Grade:** A-
+
+This project demonstrates excellent dependency management practices:
+- Minimal, focused dependencies
+- No security vulnerabilities
+- Clean dependency tree
+- Well-maintained packages
+
+The only improvement needed is updating package.json version constraints to match the currently installed (and tested) versions. This is a minor documentation update rather than a functional change.
+
+**No major refactoring or cleanup required.**

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@astrojs/tailwind": "^6.0.2",
-    "astro": "^5.10.0",
-    "tailwindcss": "^3.4.17"
+    "astro": "^5.16.11",
+    "tailwindcss": "^3.4.19"
   }
 }


### PR DESCRIPTION
- Update astro from ^5.10.0 to ^5.16.11
- Update tailwindcss from ^3.4.17 to ^3.4.19
- Add comprehensive dependency audit report

Audit findings:
- 0 security vulnerabilities detected
- No unnecessary bloat (149MB, 350 packages)
- All dependencies are essential for Astro functionality
- Build verified successfully with updated versions

Note: Tailwind v4 upgrade not possible due to @astrojs/tailwind peer dependency requiring v3.x