### PR TITLE
Fix JSON parsing error in tech stack chart

### DIFF
--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -179,9 +179,7 @@ const techCounts = allTechnologies.map(tech => ({
       </div>
 
       <!-- Data for d3 (hidden, available for JavaScript) -->
-      <script type="application/json" id="tech-data">
-        {JSON.stringify(techCounts)}
-      </script>
+      <script type="application/json" id="tech-data" set:html={JSON.stringify(techCounts)} />
     </section>
   </div>
 


### PR DESCRIPTION
- Use set:html directive to properly inject JSON data
- Fixes 'Uncaught SyntaxError' in browser console
- Chart should now render correctly