### PR TITLE
Publish the "Building ADO Companion" blog series as reviewable drafts

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -13,6 +13,8 @@ const blog = defineCollection({
     author: z.string().default('Jason Paladini'),
     featured: z.boolean().default(false),
     draft: z.boolean().default(false),
+    series: z.string().optional(),
+    part: z.number().optional(),
   }),
 });
 

--- a/src/content/blog/ado-ai-copilot-agent.md
+++ b/src/content/blog/ado-ai-copilot-agent.md
@@ -1,0 +1,218 @@
+---
+title: "From dashboards to an agent: giving ADO Companion an AI copilot that actually does things"
+description: "Why we replaced 'chat with your data' with a tool-calling agent that creates and edits work items — and the propose-then-apply pattern that makes AI write access something you can defend in front of a security review."
+date: 2026-07-02
+category: "AI agents"
+readingTime: "11 min"
+tags: [databricks, azure-devops, ai-agents, tool-calling, fmapi, genie, fastapi, llm]
+author: "Jason Paladini"
+draft: true
+series: "Building ADO Companion"
+part: 3
+---
+> Part 3 of the **ADO Companion** series. Part 1 built the app and the delivery pipeline; Part 2 chose OData for the analytics plane. This one is about the moment the roadmap changed shape: we stopped building a smarter dashboard and started building an **agent** — one that creates work items, cleans up descriptions, and tags a sprint's worth of backlog, with every change gated behind a human click.
+
+<!-- 📸 Screenshot slot — HERO: The AI Copilot tab mid-conversation: read-tool chips at the top of an answer, and a proposal card ("Update work item #4") with Apply / Dismiss buttons. This is the whole thesis in one image. -->
+
+---
+
+## TL;DR
+
+We added an **AI Copilot** tab to ADO Companion: a tool-calling agent running on a **Databricks Foundation Model APIs serving endpoint**, wired to the same FastAPI backend the rest of the app uses. The design rests on three decisions:
+
+1. **The agent acts, it doesn't just answer.** Reading is table stakes; the value is *create this work item, fix that description, tag these five items*.
+2. **Propose-then-apply.** The agent's writes never execute directly. Each one comes back as a proposal card; clicking **Apply** routes through the exact same REST endpoint a human edit uses — same audit log, same permissions, same code path.
+3. **Everything is config.** The model endpoint name and the tracing experiment are per-workspace secrets. Moving from a personal dev workspace to a corporate one is a secret swap, not a rewrite.
+
+And a structural bonus: the **Genie Space from Part 2 didn't get replaced — it got demoted to a tool.** The agent calls it when a question is historical, and answers from the live API when it isn't.
+
+---
+
+## 1. The realization: BI answers questions, but work is verbs
+
+The Genie analytics chat from Phase 3 worked. Ask "how many open work items by state," get a real answer with a real table behind it. But watching actual usage made something obvious: the questions were almost always a *prelude to an action*. You ask what's stale **because you want to clean it up**. You ask who's overloaded **because you want to reassign something**.
+
+A BI chat can't do any of that. Genie is, by design, read-only SQL over Delta tables. The wish list that accumulated looked like this:
+
+- Create work items from a sentence ("make a task to tighten the release checklist, assign it to me").
+- Edit and *clean up* work items — fix weak descriptions, normalize tags, set iterations.
+- Eventually: review PRs and comment on files, generate PDF/Excel artifacts, make gated table edits.
+
+That's not a chart with a better prompt. That's an **agent with tools** — and it forced a genuinely different architecture.
+
+---
+
+## 2. The decisions that shaped it
+
+Same discipline as Part 1: name the constraints, let them pick the design.
+
+| Decision | Choice | Why |
+|---|---|---|
+| **Where does the model run?** | Databricks FMAPI serving endpoint, name from config | Our runtime-AI policy is Databricks-native only — no external AI vendor calls in the product. FMAPI endpoints speak standard chat-completions with function calling, so the agent code doesn't care which model is behind the name. |
+| **What can the agent touch?** | Only what the BFF already exposes | The Phase 4B CRUD work (create/update/comment, identity search, iterations) *is* the tool library. The agent gets no private side door — it literally cannot see or do more than the app itself. |
+| **Do writes execute in the loop?** | Never. Propose-then-apply | AI write access is the part that fails a security review. Making every mutation a human-approved proposal that flows through the normal REST route means the audit log can't tell an AI-initiated change from a human one — because *mechanically it is one*. |
+| **What about the Genie Space?** | It becomes one tool among many | One chat surface. The agent routes historical/BI questions to Genie and live questions to the REST tools, and is required to say which plane an answer came from. |
+| **Model quality vs. availability?** | Endpoint name is a secret | Dev runs `databricks-llama-4-maverick` (Free Edition rate-limits the Claude endpoints to zero). The corporate workspace flips one secret to `databricks-claude-sonnet-5`. Zero code changes. |
+
+The through-line: **the agent is a client of the app, not a superuser of it.**
+
+---
+
+## 3. Propose-then-apply: the load-bearing decision
+
+Everything else is plumbing; this is the pattern worth stealing.
+
+The agent loop distinguishes two kinds of tools:
+
+- **Read tools execute immediately** — list work items, get detail, search identities, list PRs and builds, pull the analytics summary. Reading through the app's own client is safe by construction.
+- **Write tools never execute in the loop.** When the model calls `create_work_item` or `update_work_item`, the server *records* the call — name and arguments — and returns it to the UI as a **proposal**. The model is told "recorded, the user will review it," and moves on.
+
+The UI renders each proposal as a card: a human-readable title, the fields as a table, and **Apply / Dismiss** buttons. Apply doesn't invoke anything agent-specific — it calls `PATCH /api/projects/{p}/workitems/{id}`, the very endpoint the edit drawer uses. Which means:
+
+- The **audit middleware** logs it identically (who, what, when, outcome).
+- The **permission surface** is identical — the agent can't be phished into a write path the UI doesn't have.
+- Rolling the feature back would leave zero orphaned infrastructure. The agent is additive.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as User
+    participant UI as React UI<br/>(AI Copilot tab)
+    participant BFF as FastAPI BFF<br/>/api/copilot/chat
+    participant M as FMAPI endpoint<br/>(chat + tools)
+    participant ADO as Azure DevOps<br/>REST API
+
+    U->>UI: "Tag these two items 'triage'"
+    UI->>BFF: message + history
+    BFF->>M: messages + tool schemas
+    M-->>BFF: tool_call: list_work_items
+    BFF->>ADO: GET work items (read tool: executes)
+    ADO-->>BFF: rows
+    BFF->>M: tool result
+    M-->>BFF: tool_call: update_work_item ×2
+    Note over BFF: write tools DO NOT execute —<br/>recorded as proposals p1, p2
+    BFF-->>UI: reply + 2 proposal cards
+    U->>UI: clicks Apply on p1
+    UI->>BFF: PATCH /workitems/1 (the normal REST route)
+    BFF->>ADO: JSON-Patch update
+    Note over BFF,ADO: same code path, same audit log<br/>as a human edit
+```
+
+<details class="diagram-note">
+  <summary>Diagram description (text version)</summary>
+  <p>A sequence diagram with five vertical lifelines, left to right: User, React UI (AI Copilot tab), FastAPI BFF, FMAPI endpoint, Azure DevOps REST API. The user sends "Tag these two items 'triage'" to the UI, which forwards it to the BFF, which sends messages plus tool schemas to the FMAPI endpoint. The model responds with a `list_work_items` tool call; the BFF executes it against Azure DevOps and returns the result to the model (annotate this exchange "read tools execute immediately"). The model then responds with two `update_work_item` tool calls; a highlighted note over the BFF says "write tools DO NOT execute — recorded as proposals." The BFF returns the reply plus two proposal cards to the UI. Finally, the user clicks Apply, and the UI calls the ordinary REST route (PATCH /workitems/1) through the BFF to Azure DevOps, with a closing note: "same code path, same audit log as a human edit." The visual message: the AI's writes detour through a human click and rejoin the normal path.</p>
+</details>
+
+<!-- 📸 Screenshot slot: A proposal card close-up — "Update work item #4" with the field table, Apply/Dismiss, and (in a second shot) the green applied chip after clicking. -->
+
+---
+
+## 4. The tool registry: your BFF is already the SDK
+
+The most satisfying part of the build was how little new surface it required. The Phase 4B work — full work-item CRUD, identity search, comments — had already forced clean, typed methods on the ADO client. The tool registry is those methods with JSON-Schema descriptions stapled on:
+
+| Tool | Kind | Backed by |
+|---|---|---|
+| `list_work_items`, `get_work_item`, `list_work_item_comments` | read | the same client methods the Work Items tab uses |
+| `search_identities` | read | the assignee picker's endpoint |
+| `list_pull_requests`, `list_builds` | read | the PR / Pipelines tabs' endpoints |
+| `get_analytics_summary` | read | the OData `$apply` aggregates from Part 2 |
+| `query_analytics_history` | read | **the Genie Space from Part 2**, as a tool |
+| `create_work_item`, `update_work_item`, `add_work_item_comment` | **write → proposal** | the REST routes, via the Apply button |
+
+This creates a compounding loop we didn't fully appreciate until it happened: **every feature the app gains, the agent gains.** When the code browser lands (Phase 4F), its file/diff endpoints become the agent's PR-review tools for free. Build the product; the agent inherits it.
+
+---
+
+## 5. The loop itself
+
+The implementation is deliberately boring — about 300 lines of Python in one module. One user message triggers up to eight model calls:
+
+```python
+# the shape of it (abridged)
+for _ in range(MAX_TURNS):                      # 8
+    data = await _invoke(endpoint, messages, ALL_TOOLS)
+    msg = data["choices"][0]["message"]
+    for tc in msg.get("tool_calls") or []:
+        if tc.name in WRITE_TOOL_NAMES:
+            problem = await _verify_write_target(tc.name, tc.args, project)
+            result = {"error": problem} if problem else record_proposal(tc)
+        else:
+            result = await _run_read_tool(tc.name, tc.args, project)
+        messages.append(tool_result(tc, result))
+    if not msg.get("tool_calls"):
+        return reply
+```
+
+Implementation notes that mattered:
+
+- **The wire protocol is plain chat-completions.** `POST {workspace}/serving-endpoints/{name}/invocations` with `messages` and `tools`. Auth comes from `WorkspaceClient().config.authenticate()`, which hands back refreshed bearer headers whether the caller is the app's service principal in production or a PAT in dev. No SDK abstraction needed on top.
+- **Verify before you propose.** Before an `update_work_item` proposal surfaces, the server does a cheap `get_work_item` on the target. If it 404s, the proposal is rejected and the error goes back to the *model*, mid-loop, so it self-corrects — re-lists, finds the real IDs, re-proposes. (Models will confidently assume work item IDs are sequential. Don't let optimism reach the UI.)
+- **Outcomes round-trip.** The UI appends a small `[Proposal outcomes: …]` note — applied, dismissed, or failed — to the conversation history it sends on the next turn. So "try again" and "now do the rest" just work, and nothing already applied gets re-proposed.
+- **Meet the model where it is.** Reasoning models return content as typed blocks; llama-family models occasionally emit the second tool call of a multi-item request as *plain text*. A small fallback parser lifts those into real tool calls. Worth one paragraph, not five — the point is that the loop absorbs model quirks so the product behavior stays clean, and the traces (Part 4) make each quirk a ten-minute fix instead of a mystery.
+
+---
+
+## 6. Two planes, one agent
+
+Part 2 ended with a rule: never imply batch data is real-time. The agent inherits that rule as *prompt policy*. Its system prompt tells it: the REST tools are **live**; `query_analytics_history` is **batch** (Delta, refreshed daily); use the right one and say which you used.
+
+```mermaid
+flowchart LR
+  U([User]) --> C[AI Copilot<br/>agent loop]
+
+  C == "live · read + propose" ==> ADO[(Azure DevOps<br/>REST API)]
+  C -. "batch · Genie tool" .-> LAKE[(Delta tables<br/>Genie Space)]
+  JOB[Scheduled ingest<br/>OData -> Delta] -. daily .-> LAKE
+
+  P[Proposal cards<br/>Apply / Dismiss] --> ADO
+  C --> P
+
+  classDef live fill:#E7EEFC,stroke:#2D6CDF,color:#15191E;
+  classDef plan fill:#EFEAFE,stroke:#7A5AF8,color:#15191E,stroke-dasharray:4 3;
+  classDef gate fill:#E4F3EA,stroke:#138A4E,color:#15191E;
+  class ADO live;
+  class LAKE,JOB plan;
+  class P gate;
+```
+
+<details class="diagram-note">
+  <summary>Diagram description (text version)</summary>
+  <p>A left-to-right diagram. On the left, a rounded "User" node points into a box labeled "AI Copilot — agent loop." From that box, a bold solid blue arrow labeled "live · read + propose" goes to a blue cylinder "Azure DevOps REST API." A dashed purple arrow labeled "batch · Genie tool" goes to a purple cylinder "Delta tables + Genie Space," which is fed from below by a box "Scheduled ingest: OData → Delta" with a dashed arrow labeled "daily." Between the agent and the live cylinder, insert a green box "Proposal cards — Apply / Dismiss": the agent points into it, and it points into the Azure DevOps cylinder — showing that the write path detours through a human gate while reads go direct. Blue = live plane, purple = batch plane, green = the human gate. The message: one agent, two data planes, and writes always pass through the green box.</p>
+</details>
+
+The nice second-order effect: the Analytics tab got *simpler*. Its chat moved into the copilot, and the tab is now free to become what it should have been all along — filtered report widgets over the OData aggregates (that's Phase 4C).
+
+---
+
+## 7. Picking the model like you pick a region
+
+Because the endpoint name is a secret, model selection became an operational decision instead of an architectural one. The practice we settled on:
+
+1. `GET /api/2.0/serving-endpoints` and shortlist the `llm/v1/chat` endpoints.
+2. **Smoke-test tool calling before committing** — one message, one tool schema, confirm the response's `finish_reason` is `tool_calls`. (On Free Edition this instantly revealed that the Claude endpoints, while listed, are rate-limited to zero — so dev runs on `databricks-llama-4-maverick`, which tool-calls reliably.)
+3. Set the secret. The app picks it up at runtime; there is no redeploy.
+
+The same three steps, run in a corporate workspace, land on `databricks-claude-sonnet-5`. That's the whole migration.
+
+---
+
+## 8. Lessons learned
+
+- **Verbs, not answers.** The jump from "chat with your data" to "agent with tools" is where the product value actually lives — and it's a smaller jump than it looks if your backend is already clean.
+- **Propose-then-apply is the pattern.** It converts "the AI edited production data" — a sentence that ends projects — into "the AI drafted a change and a human applied it through the normal path." Same capability, defensible story.
+- **Route writes through existing endpoints.** Audit, permissions, and rollback all come free. Resist the temptation to give the agent its own executor.
+- **The BFF is the SDK.** Every well-typed endpoint you build for humans is a tool you've already built for the agent.
+- **Make the model a config value.** Availability differs per workspace, quality differs per model, and neither should touch your code.
+
+---
+
+## 9. What's next
+
+The agent's tool list grows with the app: **PR review tools** once the code browser (4F) lands its file/diff endpoints, **artifact generation** (PDF and Excel outputs from conversations), and **gated table edits** for the app's own Delta store. Before that, Phase 4C turns the Analytics tab into proper report widgets.
+
+And there's a companion question this post deliberately deferred: when an agent acts on production systems, **how do you see what it did and why?** That's Part 4 — instrumenting the agent with MLflow Tracing, and the two incidents that made the investment pay for itself in the first week.
+
+---
+
+*Same delivery loop as always: every change in this post shipped through GitHub → mirror → an Azure DevOps PR a human merged → Azure Pipeline → `databricks bundle deploy`. The agent that edits work items cannot merge its own code. That's not an accident.*

--- a/src/content/blog/ado-analytics-odata.md
+++ b/src/content/blog/ado-analytics-odata.md
@@ -1,0 +1,214 @@
+---
+title: "Three ways to pull Azure DevOps analytics — and why we chose server-side OData"
+description: "A deep dive on sourcing data for the ADO Companion analytics dashboard: WIQL + manual aggregation vs. the Analytics OData feed vs. ingesting into Delta for Genie — and why the right answer is to sequence them, not pick one."
+date: 2026-06-29
+category: "Deep dive"
+readingTime: "10 min"
+tags: [azure-devops, analytics, odata, databricks, genie, dashboards, fastapi]
+author: "Jason Paladini"
+draft: true
+series: "Building ADO Companion"
+part: 2
+---
+> Part 2 of the **ADO Companion** series. Part 1 covered building and shipping the app on Databricks. This one is about a single, deceptively deep question: **how do you actually pull the data behind a delivery-metrics dashboard?**
+
+![ADO Companion — the Overview analytics dashboard in light mode, showing four KPI cards with sparklines, a pipeline bar chart, a work-items-by-state donut, and a recent-items table](/images/blog/ado-companion/analytics-overview-light.png)
+
+*The live dashboard. The **work-items-by-state donut** ("25 total") and the **"Open work items"** KPI (14) are **server-side OData aggregates** — `groupby((StateCategory), aggregate($count as Count))` — not a client-side count of fetched rows. The KPI's **sparkline** and its "25 total · 7d" caption come from a **`WorkItemSnapshot`** daily trend over the selected range.*
+
+---
+
+## TL;DR
+
+A dashboard needs **aggregates and trends**, not a list of rows. There are three ways to get them out of Azure DevOps:
+
+1. **WIQL + fetch-all + aggregate in our code** — what a naive first cut does. It works for tiny projects and current-state only, then falls over.
+2. **The Analytics OData feed with `$apply`** — server-side `groupby`/`aggregate`/`filter`, plus **daily snapshots** for real history. **This is the one we chose.**
+3. **Ingest OData → Delta → Genie** — the lakehouse play, needed for natural-language Q&A and to stop hammering ADO. Later, not first.
+
+The punchline: **OData is the analytics source in all three cases.** You don't choose between OData and Delta — you start by calling OData directly from the backend, and pipe the *same feed* into Delta when you're ready for Genie. Sequence, don't choose.
+
+---
+
+## 1. The problem: a dashboard is not a list
+
+The operational side of the app — the Work Items tab — wants a **list**: give me these 100 items with all their fields so I can render and edit them. That's a job for WIQL (the Work Item Query Language) plus a batch field fetch. It's the right tool there.
+
+The analytics side wants the opposite: **don't give me the rows, give me the numbers.**
+
+- *How many open items, by state?* (a donut)
+- *How has "active" trended over the last 30 days?* (a sparkline / cumulative flow)
+- *What's our weekly throughput?* (a bar series)
+
+If you compute those by pulling every work item and counting in application code, you've turned a one-number question into a thousand-row transfer. That's the trap.
+
+<!-- 📸 Screenshot slot: The work-items-by-state donut with its legend, zoomed in — the canonical "aggregate, not a list" widget. -->
+
+---
+
+## 2. Option 1 — WIQL + aggregate ourselves (the trap)
+
+The shape of this approach:
+
+1. Run a WIQL query → get back a list of work item **IDs** (capped at ~20,000).
+2. Batch-fetch fields **200 IDs at a time**.
+3. Group and count in code.
+
+It works, and for a 50-item project you'd never notice the cost. But:
+
+- **It doesn't scale.** Counting by state shouldn't require transferring every item's fields. You pay O(items) network for an O(states) answer.
+- **It's page-bound.** Beyond the WIQL cap and the 200-per-call batch, you're paginating to count.
+- **It can't do history.** WIQL describes items *as they are now*. To get "active count on each of the last 30 days," you'd issue a separate point-in-time (`AsOf`) query **per day** — 30 queries for one sparkline. That's not a trend engine; that's a workaround.
+
+Keep WIQL for the live list. Don't make it your analytics layer.
+
+```mermaid
+flowchart LR
+  Q([Count items by state]) --> W[WIQL: returns IDs<br/>max ~20k]
+  W --> B[Batch-get fields<br/>200 at a time]
+  B --> C[Group + count<br/>in app code]
+  C --> N[(One number)]
+  C -. trend? .-> D[Repeat per day<br/>AsOf x 30]
+  classDef bad fill:#FBE7E3,stroke:#D23B23,color:#15191E;
+  class D bad;
+```
+
+<details class="diagram-note">
+  <summary>Diagram description (text version)</summary>
+  <p>A left-to-right flow showing a wasteful path. Start with a rounded node "Count items by state." Arrow right to a box "WIQL: returns IDs (max ~20k)." Arrow to "Batch-get fields, 200 at a time." Arrow to "Group + count in app code." Arrow to a small cylinder "One number." Then, from the "Group + count" box, a dashed branch labeled "trend?" drops down to a red box "Repeat per day — AsOf × 30." The visual story: a long chain of heavy steps to produce a single number, and an even worse dashed detour (in red) when you ask for a trend. Color the main chain neutral grey and the trend detour red to signal "anti-pattern."</p>
+</details>
+
+---
+
+## 3. Option 2 — Analytics OData with `$apply` (the choice)
+
+Azure DevOps ships a dedicated **Analytics** service with an **OData** endpoint built for exactly this. It does the aggregation **on the server** and returns the numbers.
+
+Base URL (note the **different host**): `https://analytics.dev.azure.com/{org}/{project}/_odata/v4.0-preview/…` — same PAT auth as the REST API.
+
+**Current state, by type and state — one call:**
+```
+WorkItems?$apply=groupby((WorkItemType,State),aggregate($count as Count))
+```
+Returns one row per (type, state) with a count. That's the donut and the "open items" KPI, exact and page-independent.
+
+**Filter, then group:**
+```
+WorkItems?$apply=filter(State eq 'Active')/groupby((AssignedTo/UserName),aggregate($count as Count))
+```
+
+**Real trends via daily snapshots** — the part WIQL can't do:
+```
+WorkItemSnapshot?$apply=filter(DateValue ge 2026-06-01Z and DateValue le 2026-06-29Z)/groupby((DateValue,State),aggregate($count as Count))
+```
+The `WorkItemSnapshot` entity records each work item's values **once per day**, so this returns a count per day per state — precisely the series behind sparklines, week-over-week deltas, and cumulative-flow diagrams.
+
+Why this is the right layer:
+- **Aggregation is server-side.** One small response, not a row dump.
+- **History is native.** Snapshots make trends a single query, not N day-queries.
+- **It's the reporting surface Microsoft scales for.** Power BI's ADO connector uses the same feed.
+
+<!-- 📸 Screenshot slot: A raw OData response (JSON) for the `groupby((State), aggregate($count as Count))` query — great for showing "the server already did the math." Optional but credible. -->
+
+---
+
+## 4. Option 3 — Ingest OData → Delta → Genie (the later play)
+
+When do you graduate from "call OData live" to "copy it into the lakehouse"? When you want one of:
+
+- **Natural-language Q&A** over the data (Databricks **Genie** answers questions over Delta tables in Unity Catalog).
+- **To stop hammering ADO** (cache/rate-limit insulation), or join ADO data with other sources.
+- **Heavy historical analysis** beyond what live OData comfortably serves.
+
+The crucial detail: the **ingestion source is the same OData feed.** A scheduled job reads OData → writes Delta → a Genie Space sits on top. Nothing about Option 2 is wasted; Option 3 extends it.
+
+---
+
+## 5. The decision: sequence, don't choose
+
+```mermaid
+flowchart TD
+  START([Dashboard needs aggregates + trends]) --> Q{What's the need?}
+  Q -->|live list of items| WIQL[WIQL + batch get<br/>operational tab]
+  Q -->|counts + trends now| ODATA[Analytics OData<br/>$apply / snapshots]
+  Q -->|NL Q&A · offload ADO| DELTA[Ingest OData to Delta<br/>+ Genie Space]
+  ODATA --> PICK[(Analytics v1 — ship now)]
+  DELTA -. Phase 3 .-> PICK2[(Genie tab — later)]
+  ODATA -. same feed .-> DELTA
+  classDef now fill:#E4F3EA,stroke:#138A4E,color:#15191E;
+  classDef later fill:#EFEAFE,stroke:#7A5AF8,color:#15191E,stroke-dasharray:4 3;
+  class PICK now;
+  class PICK2,DELTA later;
+```
+
+<details class="diagram-note">
+  <summary>Diagram description (text version)</summary>
+  <p>A top-down decision diagram. Start with a rounded node "Dashboard needs aggregates + trends." Arrow down to a diamond decision "What's the need?" Three labeled branches fan out: (1) "live list of items" → box "WIQL + batch get (operational tab)." (2) "counts + trends now" → box "Analytics OData ($apply / snapshots)." (3) "NL Q&A · offload ADO" → box "Ingest OData to Delta + Genie Space." From the OData box, a solid arrow points to a green rounded node "Analytics v1 — ship now." From the Delta/Genie box, a dashed arrow labeled "Phase 3" points to a purple, dashed node "Genie tab — later." Finally, a dashed arrow labeled "same feed" connects the OData box to the Delta/Genie box, emphasizing that the lakehouse path consumes the very same OData source. Color intent: green = build now, purple/dashed = planned. The message: pick OData for v1, and the Genie path later reuses the same feed — these are stages, not competing choices.</p>
+</details>
+
+---
+
+## 6. How the queries map to the dashboard
+
+| Widget | OData query (sketch) | Entity |
+|---|---|---|
+| "Open work items" KPI | `groupby((State),aggregate($count as Count))`, sum the non-closed | `WorkItems` |
+| Work-items-by-state donut | `groupby((State),aggregate($count as Count))` | `WorkItems` |
+| KPI sparklines / state trend | `filter(DateValue …)/groupby((DateValue,State),aggregate($count as Count))` | `WorkItemSnapshot` |
+| Weekly throughput | completed-per-week via snapshot deltas or `CompletedDate` grouping | `WorkItems` / `WorkItemSnapshot` |
+| Pipeline success / runs | Builds REST API (small) now; `PipelineRun` analytics entity later | REST / Analytics |
+
+The time-range control (24h / 7d / 30d) becomes **real** here: it sets the `DateValue` window on the snapshot queries, so the numbers and sparklines actually change with the range — instead of being decorative.
+
+<!-- 📸 Screenshot slot: The Overview header showing the 24h / 7d / 30d segmented control, with a note/caption that it now drives live OData snapshot windows. -->
+
+---
+
+## 7. The data-flow we're building
+
+```mermaid
+flowchart LR
+  DASH[Overview dashboard<br/>React + TanStack Query] -->|/api/.../analytics?range=| BFF[FastAPI BFF<br/>Analytics client]
+  BFF == "$apply aggregates<br/>+ snapshot trends" ==> ODATA[(ADO Analytics OData<br/>analytics.dev.azure.com)]
+  ODATA ==> BFF
+  BFF -. Phase 3 .-> JOB[Scheduled Job<br/>OData -> Delta]
+  JOB -. .-> GENIE[(Delta + Genie Space)]
+  DASH -. future NL Q&A .-> GENIE
+  classDef live fill:#E7EEFC,stroke:#2D6CDF,color:#15191E;
+  classDef plan fill:#EFEAFE,stroke:#7A5AF8,color:#15191E,stroke-dasharray:4 3;
+  class ODATA live;
+  class JOB,GENIE plan;
+```
+
+<details class="diagram-note">
+  <summary>Diagram description (text version)</summary>
+  <p>A left-to-right data-flow diagram. On the left, a box "Overview dashboard (React + TanStack Query)" with an arrow labeled "/api/.../analytics?range=" pointing right to a box "FastAPI BFF (Analytics client)." Between the BFF and a blue cylinder labeled "ADO Analytics OData — analytics.dev.azure.com," draw a bold double-headed/round-trip arrow labeled "$apply aggregates + snapshot trends" (request out, aggregated numbers back). Color that cylinder blue = the live path that exists now. Then, from the BFF, a dashed arrow labeled "Phase 3" points down/right to a box "Scheduled Job: OData → Delta," which has a dashed arrow to a purple cylinder "Delta + Genie Space." Finally a dashed arrow labeled "future NL Q&A" goes from the dashboard directly to the Genie cylinder. Visual intent: solid blue = today's live OData aggregation path; dashed purple = the planned lakehouse/Genie extension fed by the same OData source.</p>
+</details>
+
+![The same dashboard with the time range set to 30d — the Open KPI caption now reads "25 total · 30d" and the sparkline shows the longer trend window](/images/blog/ado-companion/analytics-overview-30d.png)
+
+*The payoff: switching the range to **30d** refetches the OData snapshot window. The KPI caption becomes **"25 total · 30d"** and the sparkline redraws over the longer trend. The 24h / 7d / 30d control is now **real**, not decorative — it sets the `DateValue` window on the `WorkItemSnapshot` query.*
+
+---
+
+## 8. One gotcha worth flagging
+
+The Analytics endpoint lives on a **different host** — `analytics.dev.azure.com` — not the `dev.azure.com` host the operational REST API uses. Same PAT, different base URL. So the backend gets a **separate, small Analytics client** alongside the existing REST client, rather than reusing the same base. Minor, but it'll bite you if you assume one host.
+
+---
+
+## 9. What shipped — and what's next
+
+**Shipped (this post's screenshots are the real thing):**
+
+- A BFF **Analytics client** that calls OData `$apply`: `count_by_state_category` (a `groupby((StateCategory))` count) and `open_trend` (a `WorkItemSnapshot` daily series over a date window).
+- One endpoint, `GET /api/projects/{project}/analytics?range=24h|7d|30d`, returning `byCategory`, `open`, `total`, `trend`, and an `available` flag. It **degrades gracefully**: if a workspace doesn't have Analytics/snapshots enabled, it returns `available: false` and the dashboard falls back to a client-side rollup instead of breaking.
+- The **Overview dashboard rewired** to those aggregates: the donut and "Open work items" KPI are now exact (not page-bound), and the **24h / 7d / 30d control is live** — it sets the snapshot date window, so the numbers and the sparkline actually change.
+
+**Next (Phase 3):** the OData → Delta ingestion job and a **Genie Space** for natural-language questions over the same data — fed by the very feed this dashboard already queries.
+
+The headline lesson for anyone building reporting on Azure DevOps: **don't aggregate work items yourself. Ask the Analytics service to do it — and treat that same feed as the on-ramp to your lakehouse.**
+
+---
+
+*Sources: Microsoft Learn — [Aggregate work tracking data with Analytics](https://learn.microsoft.com/en-us/azure/devops/report/extend-analytics/aggregated-data-analytics), [Query trend data with OData aggregation](https://learn.microsoft.com/en-us/azure/devops/report/extend-analytics/querying-for-trend-data), [OData Analytics query guidelines](https://learn.microsoft.com/en-us/azure/devops/report/extend-analytics/odata-query-guidelines).*

--- a/src/content/blog/ado-mlflow-tracing.md
+++ b/src/content/blog/ado-mlflow-tracing.md
@@ -1,0 +1,175 @@
+---
+title: "You can't operate an agent you can't see: MLflow Tracing for an in-app AI copilot"
+description: "How we instrumented ADO Companion's tool-calling agent with MLflow Tracing from day one — the span design, the graceful-degradation rule, and two production diagnoses that took ten seconds each because the traces already existed."
+date: 2026-07-02
+category: "Observability"
+readingTime: "9 min"
+tags: [databricks, mlflow, tracing, observability, ai-agents, llmops, fmapi]
+author: "Jason Paladini"
+draft: true
+series: "Building ADO Companion"
+part: 4
+---
+> Part 4 of the **ADO Companion** series. Part 3 gave the app a tool-calling agent with propose-then-apply write gating. This post is about the other half of trusting an agent in production: **observability**. We wired MLflow Tracing into the agent loop before the feature shipped — and it started paying for itself the same day.
+
+<!-- 📸 Screenshot slot — HERO: The MLflow Traces tab for the `ado-companion-copilot` experiment: a list of `copilot.turn` traces, one expanded to show the nested `llm` and `tool:*` spans with timings. This is the post's thesis as a UI. -->
+
+---
+
+## TL;DR
+
+Every copilot turn — question, model calls, tool executions, proposals — is logged as a **trace** in a Databricks-hosted MLflow experiment. The design fits in three sentences:
+
+1. One user message = one `copilot.turn` trace, with child spans for every model call (`llm`), every tool execution (`tool:{name}`), and every write-target check (`verify:{name}`).
+2. The experiment ID is a **per-workspace secret**; tracing is **optional and never fatal** — a misconfigured experiment degrades to "no traces," never to "no answers."
+3. When something looks wrong in chat, you don't guess: **open the trace and read what the model actually saw and did.**
+
+That third sentence is the whole business case. We had two odd behaviors in the first day of real usage, and both were diagnosed from traces in seconds — not by adding print statements and asking the user to reproduce.
+
+---
+
+## 1. The decision: tracing is part of the feature, not an add-on
+
+Dashboards get away without deep instrumentation because their failure mode is visible — a wrong number on a screen. An agent's failure modes are *conversational*: it did something reasonable-looking for reasons you can't see. Which tools did it call? With what arguments? What came back? What did the context window contain by turn four?
+
+Without answers, every user report starts a guessing game. So the rule we set before writing the loop: **no agent in the product without a flight recorder.**
+
+Why MLflow specifically, when the runtime already lives on Databricks:
+
+| Consideration | What MLflow Tracing gives us |
+|---|---|
+| **Zero new infrastructure** | Traces land in a workspace **experiment** — a resource that already exists, with its own ACLs. No collector, no vendor, no sidecar. |
+| **The right shape** | Traces/spans map one-to-one onto an agent loop: turn → model calls → tool runs. We didn't have to invent a schema. |
+| **Same-platform policy** | The runtime-AI rule from Part 1 (Databricks-native only) extends naturally to telemetry. Question data stays in the workspace. |
+| **A UI we didn't build** | The experiment's Traces tab gives search, timing waterfalls, and input/output inspection for free. |
+
+The dependency cost is one package: `mlflow-skinny` — the tracing-and-client subset, not the full server.
+
+---
+
+## 2. What a turn looks like
+
+The span tree mirrors the loop's actual structure, so reading a trace *is* reading the turn:
+
+```mermaid
+flowchart TB
+  T["copilot.turn<br/>inputs: message, history size<br/>attrs: endpoint, project"]
+  T --> L1["llm (call 1)<br/>out: finish_reason, token usage"]
+  T --> TO1["tool:list_work_items<br/>in: args · out: result (truncated)"]
+  T --> L2["llm (call 2)"]
+  T --> V1["verify:update_work_item<br/>in: target id · out: rejected?"]
+  T --> L3["llm (call 3)"]
+  T --> O["outputs: reply, tools used,<br/>proposals made"]
+
+  classDef turn fill:#E7EEFC,stroke:#2D6CDF,color:#15191E;
+  classDef llm fill:#EFEAFE,stroke:#7A5AF8,color:#15191E;
+  classDef tool fill:#E4F3EA,stroke:#138A4E,color:#15191E;
+  classDef verify fill:#FFF6E5,stroke:#B7791F,color:#15191E;
+  class T,O turn;
+  class L1,L2,L3 llm;
+  class TO1 tool;
+  class V1 verify;
+```
+
+<details class="diagram-note">
+  <summary>Diagram description (text version)</summary>
+  <p>A top-to-bottom tree diagram. The root node, in blue, is "copilot.turn" annotated with its inputs (the user message and history size) and attributes (endpoint name, project). From the root, five children hang in chronological order, left to right or stacked: a purple node "llm (call 1)" annotated "finish_reason, token usage"; a green node "tool:list_work_items" annotated "args in, truncated result out"; a purple node "llm (call 2)"; an amber node "verify:update_work_item" annotated "target id in, rejected? out"; a purple node "llm (call 3)." At the bottom, a blue summary node "outputs: reply, tools used, proposals made." Color code: blue = the turn envelope, purple = model calls, green = tool executions, amber = write-target verification. The message: one trace tells the complete story of one question.</p>
+</details>
+
+Three deliberate choices in what gets recorded:
+
+- **Tool results are truncated** (500 chars in span outputs) — enough to see *what the model saw*, without turning the experiment into a data lake of work-item bodies.
+- **The `verify:*` spans record rejections.** When the server refuses to surface a write proposal (more on why below), that decision is visible in the trace, not silent.
+- **Token usage per `llm` span.** When the corporate workspace swaps in a pricier endpoint, the cost conversation starts from data, not vibes.
+
+---
+
+## 3. The implementation, and the rule that matters
+
+The wiring is small enough to show almost completely. The experiment ID resolves like every other per-workspace config in this project — env var override, then secret:
+
+```python
+def _mlflow():
+    """Return mlflow configured for our experiment, or None."""
+    try:
+        exp = resolve_experiment_id()          # env var, else ado/mlflow_experiment_id secret
+        if not exp:
+            return None
+        import mlflow
+        mlflow.set_tracking_uri("databricks")  # ambient auth: SP in prod, PAT in dev
+        mlflow.set_experiment(experiment_id=exp)
+        return mlflow
+    except Exception:
+        return None                            # tracing must never break a chat turn
+
+def _span(name, **attrs):
+    m = _mlflow()
+    return m.start_span(name=name, attributes=attrs) if m else nullcontext(None)
+```
+
+The rule in that except clause deserves its own sentence: **tracing failures degrade to silence, never to errors.** A revoked grant, a deleted experiment, a network blip — none of them may cost a user their answer. This is the same graceful-degradation posture the whole app takes (Genie unconfigured? The tab says so. Store grants missing? Settings report unavailable) applied to telemetry.
+
+Operationally, activation is two human steps in the workspace, both documented in the repo's agent runbook: create the experiment (one API call), set the secret, and grant the app's service principal `CAN_EDIT` on the experiment so it can log. Skip all of it and the copilot still works — untraced.
+
+---
+
+## 4. The payoff: two diagnoses at reading speed
+
+Both of these happened in the first day of real usage. Neither required reproducing the issue, adding logging, or redeploying.
+
+**The guessed ID.** A user asked the copilot to update *two* work items; the second proposal failed on Apply with a 404 from Azure DevOps. The trace showed the why immediately: the turn had **no `list_work_items` span** before the proposal. The model had assumed work item IDs are sequential and invented `#3` — which happened to be a deleted item sitting in the recycle bin. The fix became a design upgrade rather than a patch: the server now **verifies every update target exists before the proposal surfaces**, and a rejection is fed back to the model mid-loop so it corrects itself. Those checks are the amber `verify:*` spans — the incident is now a permanent, visible part of the loop's anatomy.
+
+**The disappearing second proposal.** Same request class — "do this to two items" — but only one proposal card appeared, and the reply text contained a strange artifact. The trace showed the model's final message verbatim: the second tool call had been emitted **as plain text** (`update_work_item(id=2, ...)`) rather than as a structured tool call — a llama-family template quirk on multi-call turns. Prompt engineering alone didn't cure it; a small fallback parser now lifts text-form calls into real ones, so no proposal is ever silently dropped.
+
+The pattern in both cases: **symptom in chat → open the trace → read the answer.** Ten seconds to diagnosis, because the instrumentation predated the incident. That's the argument for building the flight recorder before the first flight, and it's also the honest accounting: the agent misbehaved twice, the system caught both, and both fixes are now invariants with tests.
+
+<!-- 📸 Screenshot slot: A single expanded trace showing a `verify:update_work_item` span with a rejection in its outputs — the guessed-ID class of bug, caught before the user ever saw a card. -->
+
+---
+
+## 5. Verification as a designed loop, not a patch
+
+The guessed-ID incident produced what's now my favorite part of the architecture — a feedback loop *inside* the turn:
+
+```mermaid
+flowchart LR
+  M[Model proposes<br/>update_work_item] --> V{verify:<br/>target exists?}
+  V -- yes --> P[Proposal card<br/>to the user]
+  V -- "no (404)" --> E[Error fed back<br/>to the model]
+  E --> R[Model re-reads:<br/>list_work_items]
+  R --> M2[Model re-proposes<br/>with real IDs] --> V
+
+  classDef ok fill:#E4F3EA,stroke:#138A4E,color:#15191E;
+  classDef check fill:#FFF6E5,stroke:#B7791F,color:#15191E;
+  classDef err fill:#FBE7E3,stroke:#D23B23,color:#15191E;
+  class P ok;
+  class V check;
+  class E err;
+```
+
+<details class="diagram-note">
+  <summary>Diagram description (text version)</summary>
+  <p>A left-to-right cycle diagram. A box "Model proposes update_work_item" flows into an amber diamond "verify: target exists?". The "yes" branch exits right to a green box "Proposal card to the user." The "no (404)" branch drops to a red box "Error fed back to the model," which flows into "Model re-reads: list_work_items," which flows into "Model re-proposes with real IDs," which loops back into the amber diamond. The message: bad proposals never reach the human; they bounce back to the model, which self-corrects within the same turn. Green = what the user sees, amber = the server's check, red = the internal correction path the user never sees.</p>
+</details>
+
+The user experiences none of this machinery — they just see correct proposals. The traces are where the machinery stays visible, which is exactly where you want it.
+
+---
+
+## 6. Lessons learned
+
+- **Instrument before you ship, not after the first incident.** The entire value of both diagnoses was that the traces already existed.
+- **Match the span tree to the loop's structure.** turn → llm → tool → verify means reading a trace requires no decoder ring.
+- **Telemetry must be sacrificial.** Any trace-path failure degrades to "no trace." An observability feature that can take down the observed feature has negative value.
+- **Config-as-secret extends to observability.** Experiment ID, like model endpoint, is a per-workspace value — the enterprise migration story stays "set three secrets."
+- **Traces turn incidents into architecture.** Both early quirks ended their lives as permanent, tested invariants (`verify:*` spans, the text-form call parser) — visible in every future trace, not buried in a postmortem doc.
+
+---
+
+## 7. What's next
+
+The experiment currently answers "what happened in this turn." The natural extensions: **evaluation runs** over recorded questions when we trial a new endpoint (the corporate `databricks-claude-sonnet-5` swap should be a measured decision, not a vibe), and **per-user session history** in the app-state store so conversations survive a browser refresh — with the trace ID stored alongside each turn, linking the product's history to the flight recorder's.
+
+---
+
+*The propose-then-apply gate from Part 3 makes the agent safe to let act; the traces make it safe to let evolve. You need both — a gate you can't audit is just a slower way to be surprised.*

--- a/src/content/blog/building-ado-companion.md
+++ b/src/content/blog/building-ado-companion.md
@@ -1,65 +1,73 @@
 ---
-title: "Building ADO Companion: a web-first Azure DevOps app on Databricks"
-description: "How I designed, built, redesigned, and shipped a React + FastAPI Azure DevOps companion onto Databricks Apps — with an AI-assisted CI/CD path and the five bugs I hit before first deploy."
+title: "Building ADO Companion: a web-first Azure DevOps app, shipped on Databricks Apps with AI-assisted CI/CD"
+description: "How we designed, built, redesigned, and wired a full CI/CD path for a React + FastAPI Azure DevOps companion that deploys to Databricks Apps — including the five bugs we hit on the road to first deploy."
 date: 2026-06-29
 category: "Case study"
-readingTime: "12 min"
+readingTime: "15 min"
 tags: [databricks, azure-devops, react, fastapi, ci-cd, devops, asset-bundles, claude-code]
-author: Jason Paladini
-draft: false
+author: "Jason Paladini"
+draft: true
+series: "Building ADO Companion"
+part: 1
 ---
+> A field report on turning a mobile Azure DevOps client into a **web-first app hosted on Databricks**, with a fully automated GitHub → Azure DevOps → Databricks delivery pipeline — built in a single pairing session with Claude Code.
 
-A field report on turning the mobile Azure DevOps client into a web-first app hosted on Databricks, with an automated GitHub → Azure DevOps → Databricks delivery pipeline. Most of it came together in one pairing session with Claude Code. The interesting part wasn't the code — it was the seams between three platforms, and the five small bugs that live in those seams.
+<!-- 📸 Screenshot slot — HERO: The Overview dashboard in light mode (the four KPI cards, the pipeline bar chart, the donut, and the recent-items table). This is the money shot; put it right under the title. -->
 
-<figure class="img-placeholder">
-  <span>HERO — Overview dashboard, light mode: KPI cards, pipeline bar chart, work-items donut, recent-items table</span>
-</figure>
+---
 
 ## TL;DR
 
-I took the unofficial Azure DevOps mobile app as a starting point and rebuilt it for the browser — work items, pull requests, pipelines, and code — then pushed past it: a persistent app shell, a dashboard, dark mode, and write-back, so you can actually edit work items and approve or abandon PRs instead of just reading them.
+We took the unofficial **Azure DevOps mobile app** as inspiration and rebuilt it as a **web app** — work items, pull requests, pipelines, and code — then went further: a persistent app shell, a dashboard, dark mode, and **write-back** (edit work items, approve/abandon PRs) instead of read-only.
 
-The catch was where it had to live. Corporate policy allows Databricks but not external PaaS like Vercel, the source of truth had to be Azure DevOps Repos, and promotion had to follow protected branches (dev → stg → prod). So I built:
+The twist: it had to run **on Databricks Apps** (corporate policy allows Databricks, not external PaaS like Vercel), and the source of truth had to live in **Azure DevOps Repos** with a **branch-based promotion** model (dev → stg → prod). We built:
 
-- A React (Vite + TypeScript) and FastAPI app, deployed as a single Databricks App.
-- A Databricks Asset Bundle for declarative, multi-workspace deploys.
-- An Azure Pipeline that builds and deploys on every merge, authenticating as a service principal.
-- A GitHub → Azure DevOps mirror, so an AI coding agent could keep working on GitHub while ADO stayed the system of record.
+- A **React (Vite + TypeScript) + FastAPI (Python)** app, deployed as a single Databricks App.
+- A **Databricks Asset Bundle** for declarative, multi-workspace deploys.
+- An **Azure Pipeline** that builds and deploys on every merge, authenticating with a **service principal**.
+- A **GitHub → Azure DevOps mirror** so an AI coding agent could keep working on GitHub while ADO remained the system of record.
 
-And I hit five real bugs on the way to first deploy. They're all written up below — that's the part worth keeping.
+And we hit five real bugs getting to first deploy. They're all documented below — that's the useful part.
 
-## The idea
+---
 
-The reference point was a Flutter mobile client for Azure DevOps: log in, browse the board, review pull requests, watch pipelines, scan commits. Genuinely useful, but mobile-only and mostly read-only.
+## 1. The idea
 
-I wanted three things it didn't have:
+The reference was a Flutter mobile client for Azure DevOps: log in, browse work items on the board, review pull requests, watch pipelines, scan commits. Useful, but mobile-only and read-mostly.
 
-1. **Web-first.** Reachable from any browser, and easy to embed later in Teams or wrap in a Mac shell.
-2. **A workflow tool, not a viewer.** Edit work items, change state, comment, approve or abandon PRs — all written back to Azure DevOps through its REST API.
-3. **Analytics.** A dashboard with delivery metrics, and eventually natural-language Q&A over the data through Databricks Genie.
+We wanted three things it didn't have:
 
-## The constraints that shaped everything
+1. **Web-first.** Accessible from any browser, embeddable later in Teams or a Mac shell.
+2. **A real workflow tool.** Not just *view* work items — **edit** them. Change state, comment, approve/abandon PRs, all written back to Azure DevOps through its REST API.
+3. **Analytics.** A dashboard with delivery metrics, and (eventually) natural-language Q&A over the data via **Databricks Genie**.
 
-Most architecture is just a response to constraints, and mine were specific:
+<!-- 📸 Screenshot slot: Side-by-side or before/after — the original mobile app concept vs. our web Overview. (Optional, if you have a reference image.) -->
+
+---
+
+## 2. The constraints that shaped everything
+
+Good architecture is mostly a response to constraints. Ours were unusually specific:
 
 | Constraint | Consequence |
 |---|---|
-| Hosting is Databricks only (no Vercel or external PaaS) | The app runs as a Databricks App. SSR buys nothing in that context, so a React SPA + FastAPI was the obvious fit. |
-| Source of truth is Azure DevOps Repos | CI/CD is Azure Pipelines, and promotion is branch-based (dev/stg/prod). |
-| Dev happens on a personal Databricks (Free Edition) | Free Edition is serverless-only, non-commercial, and apps stop after 24 hours — fine for prototyping, not production. Everything had to be config-swappable to a corporate workspace. |
-| The AI agent develops on GitHub | I needed a bridge so GitHub work lands in ADO without manual syncing. |
+| **Hosting: Databricks only** (no Vercel/external PaaS) | The app runs *as a Databricks App*. Next.js/SSR buys nothing here — we chose a React SPA + FastAPI. |
+| **Source of truth: Azure DevOps Repos** | CI/CD is **Azure Pipelines**, and promotion is branch-based (dev/stg/prod). |
+| **Dev on a personal Databricks (Free Edition)** | Free Edition is serverless-only, non-commercial, and apps stop after 24h — fine for prototyping, not production. Everything had to be **config-swappable** to a corporate workspace. |
+| **AI agent develops on GitHub** | We needed a bridge so GitHub work lands in ADO without manual syncing. |
 
-The most consequential decision fell straight out of these: keep the operational plane separate from the analytical plane.
+The single most important design decision fell out of these: **separate the operational plane from the analytical plane.**
 
-## Architecture: two data planes
+---
 
-The app does two genuinely different kinds of work, and the usual mistake is to conflate them.
+## 3. Architecture: two data planes
 
-The operational plane talks to the live Azure DevOps REST API — list work items, change a state, approve a PR. It's low-latency, it reads and writes, and it keeps no copy of ADO data.
+The app does two fundamentally different kinds of work, and conflating them is the classic mistake.
 
-The analytical plane runs over historical ADO data ingested into Delta tables in Unity Catalog — dashboards, and later Genie's natural-language questions. It's batch, read-only, and aggregate.
+- The **operational plane** talks to the **live Azure DevOps REST API**: list work items, change a state, approve a PR. Low-latency, read **and** write. No copy of ADO data is stored.
+- The **analytical plane** runs over **historical ADO data ingested into Delta tables** in Unity Catalog: dashboards and (later) Genie natural-language questions. Batch, read-only, aggregate.
 
-One FastAPI backend serves both, running inside the Databricks App. The point of the split is resilience: the operational plane never depends on Databricks SQL or Genie, so the app stays fully usable even when the analytics warehouse is asleep or rate-limited.
+Both are served by **one FastAPI backend** running inside the Databricks App. Crucially, the operational plane never depends on Databricks SQL or Genie — so the app stays fully usable even when the analytics warehouse is asleep or rate-limited.
 
 ```mermaid
 flowchart LR
@@ -82,63 +90,67 @@ flowchart LR
   class LAKE,JOB plan;
 ```
 
-Solid blue is the live operational path that exists today; dashed purple is the analytical path that's still planned.
+<details class="diagram-note">
+  <summary>Diagram description (text version)</summary>
+  <p>A left-to-right architecture diagram. On the far left, a rounded "User in browser" node with an arrow pointing right into a large container box labeled "Databricks App: ado-companion." Inside that container, stacked vertically, are two boxes: "React SPA (Vite · TypeScript · Tailwind)" on top and "FastAPI BFF (Databricks SDK · httpx)" below it, connected by a short downward arrow labeled "/api/\*". From the FastAPI box, a bold solid arrow points right to a cylinder (database) labeled "Azure DevOps REST API," and that arrow is labeled "REST · live · read+write" (color it blue to mean the operational plane). Also from the FastAPI box, a dashed arrow points to a second cylinder labeled "Delta tables — Unity Catalog + Genie Space," labeled "SQL · Genie · planned" (color it purple, dashed, to mean future/analytical). A separate box on the bottom labeled "Scheduled Job: ADO OData → Delta" has a dashed arrow labeled "nightly" feeding the same Delta cylinder. Visual intent: solid blue = live operational path that exists today; dashed purple = analytical path that is planned.</p>
+</details>
 
-## The stack, and why
+<!-- 📸 Screenshot slot: Optional — a Databricks workspace view showing the `ado-companion` app resource, to ground "it really runs here." -->
 
-- **Frontend — React (Vite) SPA, TypeScript, Tailwind.** I picked it over Streamlit because I wanted a polished CRUD experience rather than a data-app look, and over Next.js because SSR and edge rendering are wasted inside a Databricks App.
-- **Backend — FastAPI.** It gives me first-class access to the Databricks SDK for SQL, Genie, and Unity Catalog, and the same process doubles as the backend-for-frontend to the Azure DevOps REST API via `httpx`. One backend, two planes.
-- **Data fetching — TanStack Query.** Caching, invalidation, and the optimistic-or-invalidate pattern that write-back needs.
-- **Packaging — Databricks Asset Bundles.** A declarative `databricks.yml` with per-workspace targets, so going from dev to prod is a config switch, not a rewrite.
+---
 
-The frontend builds to static assets that FastAPI serves from the same process, which keeps the Databricks App a single deployable unit.
+## 4. The stack, and why
 
-## Building it: phases 0–2
+- **Frontend — React (Vite) SPA + TypeScript + Tailwind.** Chosen over Streamlit (we wanted a polished CRUD UX, not a data-app look) and over Next.js (SSR/edge is wasted inside a Databricks App).
+- **Backend — FastAPI (Python).** First-class **Databricks SDK** for SQL/Genie/Unity Catalog, and the same process acts as the **BFF** (backend-for-frontend) to the Azure DevOps REST API via `httpx`. One backend, two planes.
+- **Data fetching — TanStack Query.** Caching, invalidation, and the optimistic-or-invalidate pattern for write-back.
+- **Packaging — Databricks Asset Bundles.** Declarative `databricks.yml` with per-workspace targets, so dev → prod is a config switch, not a rewrite.
 
-I worked in small, verifiable slices.
+The frontend is built to static assets and **served by FastAPI from the same process** — so the Databricks App is a single deployable unit.
+
+---
+
+## 5. Building it: Phases 0–2
+
+We built in deliberately small, verifiable slices.
 
 ### Phase 0 — Foundation
-
-A runnable skeleton that proved the spine end to end: React → FastAPI → Azure DevOps REST API, deployable to Databricks through the Asset Bundle. Auth was a Personal Access Token stored as a Databricks secret, with an org/project picker hitting `/api/projects`.
+A runnable skeleton proving the spine end-to-end: **React → FastAPI → Azure DevOps REST API**, deployable to Databricks via the Asset Bundle. Auth via a Personal Access Token stored as a Databricks secret; an org/project picker calling `/api/projects`.
 
 ### Phase 1 — Read parity
+Match the mobile app: a tabbed per-project view with **Work Items** (WIQL query + batch fetch), **Pull Requests** (with a status filter), **Pipelines** (recent build runs), and **Code** (repos + commits). All read live from ADO through the BFF. Response parsing was covered by tests using a mocked HTTP transport — no live ADO needed to verify the logic.
 
-Matching the mobile app: a tabbed per-project view with Work Items (a WIQL query plus a batch fetch), Pull Requests (with a status filter), Pipelines (recent build runs), and Code (repos and commits). Everything reads live from ADO through the BFF. I covered the response parsing with tests against a mocked HTTP transport, so none of that logic needs a live ADO connection to verify.
+### Phase 2 — Write-back (the part that makes it a *tool*)
+This is where it stopped being a viewer:
 
-### Phase 2 — Write-back
+- **Work items:** change state via an inline dropdown (JSON-Patch `PATCH`), add comments.
+- **Pull requests:** approve (reviewer vote), abandon, reactivate.
 
-This is the phase that turned it from a viewer into a tool:
+Every mutation goes through the FastAPI BFF, then invalidates the relevant TanStack Query so the UI reflects the new truth, with per-row error surfacing.
 
-- **Work items:** change state from an inline dropdown (a JSON-Patch `PATCH`), and add comments.
-- **Pull requests:** approve via a reviewer vote, abandon, reactivate.
+<!-- 📸 Screenshot slot: The Work Items table showing the editable state pills (the colored dropdowns) and a comment composer open below the table. -->
 
-Every mutation goes through the FastAPI BFF and then invalidates the relevant TanStack Query, so the UI reflects the new state, with errors surfaced per row.
+---
 
-<figure class="img-placeholder">
-  <span>Work Items table — editable state pills (colored dropdowns) with a comment composer open below</span>
-</figure>
+## 6. The redesign: shell, dashboard, dark mode
 
-## The redesign: shell, dashboard, dark mode
+The first cut was a centered single card. The redesign turned it into a product:
 
-The first cut was a single centered card. The redesign turned it into something that feels like a product:
+- A **persistent app shell** — left sidebar (logo, project switcher, navigation with live counts, user footer) and a top bar (breadcrumb, search, theme toggle, connection status).
+- A new **Overview dashboard** — four KPI cards with sparklines, a 14-run pipeline bar chart, a work-items-by-state donut, and a recent-items table. (Built as a **client-side rollup** from data we already fetch — no new backend endpoint required for v1.)
+- **Full dark mode** — implemented as a CSS-variable token swap, persisted to `localStorage`, applied before first paint to avoid a flash.
 
-- A persistent app shell — a left sidebar with the logo, project switcher, navigation with live counts, and a user footer; and a top bar with a breadcrumb, search, theme toggle, and connection status.
-- A new Overview dashboard — four KPI cards with sparklines, a 14-run pipeline bar chart, a work-items-by-state donut, and a recent-items table. It's a client-side rollup of data the app already fetches, so v1 needed no new backend endpoint.
-- Full dark mode — a CSS-variable token swap, persisted to `localStorage` and applied before first paint so there's no flash.
+Everything is driven by a **design-token system** (light/dark values for ~40 tokens) wired into Tailwind, so theming is consistent and a single switch flips the whole app.
 
-It's all driven by a design-token system, roughly 40 tokens with light and dark values wired into Tailwind, so a single switch flips the whole app and the theming stays consistent.
+<!-- 📸 Screenshot slot — DARK MODE: The Overview dashboard in dark mode (same view as the hero, dark). Pair it visually with the hero to show the theme switch. -->
 
-<figure class="img-placeholder">
-  <span>DARK MODE — Overview dashboard, same view as the hero, in dark theme</span>
-</figure>
+<!-- 📸 Screenshot slot: The Pull Requests tab with the Approve / Abandon action buttons and status chips. -->
 
-<figure class="img-placeholder">
-  <span>Pull Requests tab — Approve / Abandon buttons and status chips</span>
-</figure>
+---
 
-## Multi-environment and branch-based promotion
+## 7. Multi-environment and branch-based promotion
 
-Three workspaces, one per environment, promoted by protected git branches. The Asset Bundle models that with targets, and the key move is that every environment-specific value lives in per-workspace secrets rather than in files.
+Three workspaces (dev, stg, prod), one per environment, promoted by **protected git branches**. The Asset Bundle models this with **targets**, and — this is the key move — **all environment-specific configuration lives in per-workspace secrets**, not in files.
 
 ```yaml
 # databricks.yml (excerpt)
@@ -166,7 +178,7 @@ env:
   - { name: ADO_PAT,     valueFrom: ado_pat }
 ```
 
-Because the bundle and `app.yaml` are byte-for-byte identical across branches, promoting dev → stg → prod is a pure code merge. There are no config diffs to review and no way for a dev URL to leak into prod.
+Because the bundle and `app.yaml` are **byte-for-byte identical across branches**, promoting `dev → stg → prod` is a **pure code merge** — no config diffs, no risk of a dev URL leaking into prod.
 
 ```mermaid
 flowchart LR
@@ -182,9 +194,16 @@ flowchart LR
   class wsdev,wsstg,wsprod env;
 ```
 
-## CI/CD: Azure Pipelines and a service principal
+<details class="diagram-note">
+  <summary>Diagram description (text version)</summary>
+  <p>A left-to-right promotion diagram. A box labeled "feature branch" flows right into a box "dev," which flows via an arrow labeled "PR" into "stg," which flows via another "PR" arrow into "prod." These three (dev, stg, prod) sit in a horizontal row, like a pipeline. Below each of the three branch boxes, a downward arrow points to a green cylinder (database/workspace) labeled respectively "dev workspace," "stg workspace," and "prod workspace," each annotated "secrets: ado scope." The message: the same code marches left-to-right through protected branches; each branch deploys to its own workspace, and the only thing that differs between environments is the per-workspace secret values. Use a calm green for the workspace cylinders.</p>
+</details>
 
-The deploy pipeline triggers on a push to `dev`, `stg`, or `prod`. It derives the target environment from the branch name, builds the frontend, installs the Databricks CLI, validates, deploys, and starts the app. It authenticates as a service principal over OAuth machine-to-machine, so there's no human token sitting in CI.
+---
+
+## 8. CI/CD: Azure Pipelines + a service principal
+
+The deploy pipeline triggers on a push to `dev`/`stg`/`prod`, derives the target environment from the branch name, builds the frontend, installs the Databricks CLI, validates, deploys, and starts the app. It authenticates to Databricks as a **service principal** (OAuth machine-to-machine), so no human token is in CI.
 
 ```yaml
 # azure-pipelines.yml (the deploy step, abridged)
@@ -216,17 +235,20 @@ flowchart TB
   class X bad;
 ```
 
-The pipeline either dead-ends early on the wrong branch or marches straight through to a running app.
+<details class="diagram-note">
+  <summary>Diagram description (text version)</summary>
+  <p>A top-to-bottom flowchart of a CI/CD pipeline. Start with a rounded terminator node "Merge to dev." Arrow down into a diamond decision node: "Guard: is the branch dev/stg/prod?" From the diamond, a branch labeled "no" goes to a red box "Fail fast" (a dead end). The "yes" branch continues downward through a vertical sequence of rectangular steps: "Use Node 20" → "npm ci + npm run build → src/static" → "Install Databricks CLI" → "bundle validate -t dev" → "bundle deploy -t dev" → "bundle run ado_app." The final arrow lands on a green rounded terminator "App URL printed." Color the success terminator green and the fail-fast box red; keep the middle steps neutral/grey. The intent: a guarded, linear deploy that either dead-ends early on a wrong branch or marches straight to a running app.</p>
+</details>
 
-<figure class="img-placeholder">
-  <span>Azure Pipelines run — a green successful run with the stage/step list expanded</span>
-</figure>
+<!-- 📸 Screenshot slot: The Azure Pipelines run view — a green successful run with the stage/step list expanded. -->
 
-## The integration problem: GitHub ↔ Azure DevOps
+---
 
-Here's a wrinkle that doesn't show up in a tidy architecture diagram. The AI coding agent worked against a GitHub repository, but the system of record was Azure DevOps Repos. Manually syncing the two on every change is exactly the kind of toil you want to design away.
+## 9. The integration problem: GitHub ↔ Azure DevOps
 
-The fix was a GitHub Action that mirrors every push to Azure DevOps — but only feature branches, never the protected ones. The agent keeps pushing to GitHub, the branch shows up in ADO automatically, and you still open a PR into a protected branch inside ADO, which preserves the gates and the deploy pipeline.
+Here's a wrinkle that doesn't show up in tidy architecture diagrams. The AI coding agent (Claude Code) worked against a **GitHub** repository, but the system of record was **Azure DevOps Repos**. Manually syncing the two on every change is exactly the toil you don't want.
+
+The fix: a **GitHub Action that mirrors every push to Azure DevOps** — but *only* feature branches, never the protected `dev`/`stg`/`prod`. So the agent keeps pushing to GitHub; the branch lands in ADO automatically; and you still open a PR into a protected branch *inside ADO*, preserving the gates and the deploy pipeline.
 
 ```yaml
 # .github/workflows/mirror-to-ado.yml (the push, abridged)
@@ -250,58 +272,64 @@ flowchart LR
   class APP dbx;
 ```
 
-An AI agent pushes to GitHub, a mirror lands it in ADO, a PR into a protected branch fires the pipeline, and the pipeline deploys to Databricks — one assembly line across three platforms.
+<details class="diagram-note">
+  <summary>Diagram description (text version)</summary>
+  <p>A left-to-right pipeline diagram showing how code travels from an AI agent to a running app, crossing three "worlds" (GitHub, Azure DevOps, Databricks). Far left: a box "Claude Code session" with an arrow labeled "git push" to a box "GitHub repo (feature branch)." From there, an arrow labeled "GitHub Action: mirror-to-ado" points to "Azure DevOps Repos (same branch)." From there, an arrow labeled "Pull Request" points to "dev branch (protected)." From dev, an arrow labeled "trigger" points to "Azure Pipeline." Finally an arrow labeled "bundle deploy + run" points to "Databricks App (running)." Color-group the nodes: the two leftmost (Claude Code, GitHub) in neutral grey = "GitHub world"; the middle three (ADO Repos, dev branch, Azure Pipeline) in blue = "Azure DevOps world"; the final node (Databricks App) in Databricks-lava red/orange = "Databricks world." The message: an AI agent pushes to GitHub, a mirror lands it in ADO automatically, a PR into a protected branch fires the pipeline, and the pipeline deploys to Databricks — a clean assembly line across three platforms.</p>
+</details>
 
-<figure class="img-placeholder">
-  <span>GitHub Actions tab — a green "Mirror to Azure DevOps" run, and/or the ADO Branches view showing the mirrored branch</span>
-</figure>
+<!-- 📸 Screenshot slot: The GitHub Actions tab showing a green "Mirror to Azure DevOps" run; and/or the Azure DevOps Repos → Branches view showing the mirrored branch. -->
 
-## War stories: five bugs on the road to first deploy
+---
 
-The architecture is the easy part to write up. The debugging is what actually happened, and it's the most useful thing to pass on. In order:
+## 10. War stories: five bugs on the road to first deploy
+
+The architecture is the easy part to write up. The **debugging** is what actually happened — and it's the most useful thing to share. In order:
 
 ### Bug 1 — The secret reference that wasn't a path
-
-My first instinct for wiring the ADO token into the app was `valueFrom: "ado/ado_pat"` in `app.yaml`. Wrong: in Databricks Apps, `valueFrom` references a named resource declared in the bundle, not a `scope/key` string. The fix was to declare a `secret` resource in `databricks.yml` and reference it by name (`valueFrom: ado_pat`). The lesson is to read the IaC schema instead of pattern-matching from some other tool.
+First instinct for wiring the ADO token into the app was `valueFrom: "ado/ado_pat"` in `app.yaml`. Wrong: Databricks Apps' `valueFrom` references a **named resource** declared in the bundle, not a `scope/key` string. The fix was to declare a `secret` resource in `databricks.yml` and reference it by name (`valueFrom: ado_pat`). Lesson: **read the IaC schema; don't pattern-match from other tools.**
 
 ### Bug 2 — The mirror that asked for a username
-
-The first mirror used a Git `http.extraheader` to inject auth. In CI that fell back to an interactive prompt and died with `could not read Username for 'https://dev.azure.com'`. Switching to a PAT-in-URL (`https://pat:<token>@dev.azure.com/...`) and setting `GIT_TERMINAL_PROMPT=0` made auth deterministic and made failures loud instead of hanging.
+The first mirror used a Git `http.extraheader` to inject auth. In CI it fell back to an interactive prompt and died with `could not read Username for 'https://dev.azure.com'`. Switching to **PAT-in-URL** (`https://pat:<token>@dev.azure.com/...`) and setting `GIT_TERMINAL_PROMPT=0` made auth deterministic and failures loud.
 
 ### Bug 3 — The newline in the pasted secret
-
-Next failure: `url contains a newline in its password component`. The PAT had been pasted into the GitHub secret with a trailing newline — a nearly invisible copy/paste artifact. Rather than count on a clean paste every time, I sanitize the secret in the workflow with `tr -d '[:space:]'`. Never trust that a secret is whitespace-clean.
+Next failure: `url contains a newline in its password component`. The PAT had been pasted into the GitHub secret **with a trailing newline** — a near-invisible copy/paste artifact. Rather than rely on a perfect paste, we **sanitize the secret in the workflow** (`tr -d '[:space:]'`). Lesson: **never trust that a secret is whitespace-clean.**
 
 ### Bug 4 — "Variable group was not found or is not authorized"
-
-The pipeline hard-referenced an Azure DevOps variable group (`- group: databricks-dev`), but the credentials had actually been stored as pipeline variables — two different mechanisms. I dropped the required group reference so the pipeline reads from pipeline variables, and documented variable groups as the upgrade path once there are multiple workspaces. Match the YAML to how the operator actually stored the config.
+The pipeline hard-referenced an Azure DevOps **variable group** (`- group: databricks-dev`), but the credentials had been set as **pipeline variables** instead. Two different mechanisms. We dropped the required group reference so the pipeline reads from pipeline variables, and documented variable groups as the multi-workspace upgrade path. Lesson: **match the YAML to how the operator actually stored the config.**
 
 ### Bug 5 — `409 ALREADY_EXISTS: app ado-companion already exists`
+The pipeline authenticated, validated, uploaded, and then hit a wall **creating the app**: it already existed. Why? An **earlier manual deploy** (run as a *human user*) had created `ado-companion`. Now the **service principal**'s bundle had no record of it, so it tried to *create* rather than *update*. The fix: delete the orphaned app and let the SP create and own it — then deploy **only through the pipeline** thereafter, so there's a single owner. Lesson: **pick one identity to own a resource; mixing a human and an SP guarantees a collision.**
 
-The pipeline authenticated, validated, uploaded, and then hit a wall creating the app: it already existed. An earlier manual deploy, run as a human user, had created `ado-companion`. The service principal's bundle had no record of that, so it tried to create rather than update. The fix was to delete the orphaned app, let the service principal create and own it, and from then on deploy only through the pipeline so there's a single owner. Pick one identity to own a resource — mixing a human and a service principal guarantees a collision.
+<!-- 📸 Screenshot slot: Optional but great for credibility — the actual pipeline log showing the `409 ALREADY_EXISTS` error, then a follow-up screenshot of the green run after the fix. -->
 
-<figure class="img-placeholder">
-  <span>THE PAYOFF — the deployed app on its Databricks Apps URL, showing real Azure DevOps data</span>
-</figure>
+<!-- 📸 Screenshot slot — THE PAYOFF: The deployed app running on its Databricks Apps URL, showing real Azure DevOps data. -->
 
-## Lessons learned
+---
 
-- **Name your constraints before your tools.** "Databricks-only host" and "ADO is the source of truth" decided the entire stack and CI design.
-- **Separate the planes.** Keeping the live operational path independent of the analytical one means the core app degrades gracefully and stays simple.
-- **Config in secrets, code identical across environments.** It makes branch-based promotion a pure merge — the cleanest multi-environment story I know.
-- **One owner per resource.** That 409 was entirely about a human and a service principal both trying to own the same app.
-- **Automate the boring bridge.** The GitHub → ADO mirror removed a recurring manual sync and let the AI agent and the corporate process coexist.
-- **The bugs are the content.** Every failure above is something the next person will hit, so writing them down is the highest-leverage part of the whole exercise.
+## 11. Lessons learned
 
-## What's next
+- **Constraints first.** "Databricks-only host" and "ADO is the source of truth" decided the entire stack and CI design. Name your constraints before you name your tools.
+- **Separate planes.** Keeping the live operational path independent of the analytical path means the core app degrades gracefully and stays simple.
+- **Config in secrets, code identical across envs.** This makes branch-based promotion a pure merge — the cleanest multi-environment story we know.
+- **One owner per resource.** The 409 was entirely about a human and a service principal both trying to own the same app.
+- **Automate the boring bridge.** The GitHub→ADO mirror removed a recurring manual sync and let the AI agent and the corporate process coexist.
+- **The bugs are the content.** Every failure above is a thing the next person will hit. Writing them down is the highest-leverage part of the post.
 
-The operational app is real today. The analytical plane is the next build:
+---
 
-1. A scheduled OData → Delta ingestion job to land ADO history in Unity Catalog.
-2. A Genie Space over those tables.
-3. An in-app natural-language Q&A panel calling the Genie Conversation API, plus real week-over-week trend deltas behind the dashboard's time-range control.
+## 12. What's next
 
-After that, the surface variants: a Microsoft Teams tab (same codebase, Entra SSO) and a Tauri Mac shell, both wrapping the one web app.
+The operational app is real today. The **analytical plane** is the next build:
+
+1. A scheduled **OData → Delta** ingestion job to land ADO history in Unity Catalog.
+2. A **Genie Space** over those tables.
+3. An in-app **natural-language Q&A** panel calling the **Genie Conversation API**, plus real week-over-week trend deltas behind the dashboard's time-range control.
+
+After that: surface variants — a **Microsoft Teams tab** (same codebase, Entra SSO) and a **Tauri Mac shell** — all wrapping the one web app.
+
+<!-- 📸 Screenshot slot: Optional teaser — a mock of the planned Genie/Analytics tab, if you want to end on a forward-looking note. -->
+
+---
 
 ## Appendix — repository layout
 

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,0 +1,11 @@
+import { getCollection } from 'astro:content';
+
+// Drafts are hidden only in the real production build on Vercel.
+// Preview deploys (VERCEL_ENV=preview) and local dev/builds include them,
+// so drafts can be reviewed at their real URLs before being published.
+export const includeDrafts = process.env.VERCEL_ENV !== 'production';
+
+export async function getPosts() {
+  const posts = await getCollection('blog', ({ data }) => includeDrafts || !data.draft);
+  return posts.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,9 +1,10 @@
 ---
 import MainLayout from '../../layouts/MainLayout.astro';
-import { getCollection, render } from 'astro:content';
+import { render } from 'astro:content';
+import { getPosts } from '../../lib/blog';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('blog', ({ data }) => !data.draft);
+  const posts = await getPosts();
   return posts.map((post) => ({
     params: { slug: post.id },
     props: { post },
@@ -15,11 +16,21 @@ const { Content } = await render(post);
 
 const monthFmt = new Intl.DateTimeFormat('en-US', { month: 'short', year: 'numeric' });
 
-// Pick a related post: the most recent other post.
-const others = (await getCollection('blog', ({ data }) => !data.draft))
-  .filter((p) => p.id !== post.id)
-  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
-const related = others[0] ?? null;
+const all = await getPosts();
+
+// Posts in the same series, ordered by part number.
+const seriesPosts = post.data.series
+  ? all
+      .filter((p) => p.data.series === post.data.series)
+      .sort((a, b) => (a.data.part ?? 0) - (b.data.part ?? 0))
+  : [];
+const seriesIndex = seriesPosts.findIndex((p) => p.id === post.id);
+const prevPart = seriesIndex > 0 ? seriesPosts[seriesIndex - 1] : null;
+const nextPart = seriesIndex >= 0 && seriesIndex < seriesPosts.length - 1 ? seriesPosts[seriesIndex + 1] : null;
+
+// Pick a related post: next in series, else the most recent other post.
+const others = all.filter((p) => p.id !== post.id && p.data.series !== post.data.series);
+const related = nextPart ?? others[0] ?? null;
 ---
 
 <MainLayout
@@ -31,7 +42,12 @@ const related = others[0] ?? null;
   <header class="border-b border-white/[0.07]">
     <div class="max-w-article mx-auto px-8 pt-[60px] pb-11">
       <a href="/blog" class="font-mono text-xs text-accent no-underline hover:text-accent-bright transition-colors">← All posts</a>
-      <div class="mt-[26px] font-mono text-[11px] text-accent uppercase tracking-[0.16em]">{post.data.category}</div>
+      <div class="mt-[26px] font-mono text-[11px] text-accent uppercase tracking-[0.16em]">
+        {post.data.series ? `${post.data.series} · Part ${post.data.part}` : post.data.category}
+        {post.data.draft && (
+          <span class="ml-3 normal-case tracking-normal text-[10px] text-amber-300 border border-amber-300/40 rounded px-1.5 py-0.5">draft — hidden in production</span>
+        )}
+      </div>
       <h1 class="mt-4 mb-0 font-bold text-[clamp(32px,5vw,46px)] leading-[1.06] tracking-[-0.025em]">{post.data.title}</h1>
       <div class="flex items-center gap-3.5 mt-6 font-mono text-xs text-text-faint">
         <span>{post.data.author}</span><span>·</span>
@@ -56,6 +72,29 @@ const related = others[0] ?? null;
       </div>
     )}
   </article>
+
+  {seriesPosts.length > 1 && (
+    <section class="max-w-article mx-auto px-8 pt-2 pb-4">
+      <div class="p-[26px] px-7 border border-white/[0.09] rounded-[14px] bg-panel">
+        <span class="font-mono text-[11px] text-text-faint uppercase tracking-[0.14em]">{post.data.series} — {seriesPosts.length} parts</span>
+        <ol class="list-none m-0 mt-3.5 p-0 flex flex-col gap-2">
+          {seriesPosts.map((p) => (
+            <li class="m-0">
+              {p.id === post.id ? (
+                <span class="font-mono text-[13px] text-accent">Part {p.data.part} · {p.data.title} ←</span>
+              ) : (
+                <a href={`/blog/${p.id}`} class="font-mono text-[13px] text-text-3 no-underline hover:text-accent transition-colors">Part {p.data.part} · {p.data.title}</a>
+              )}
+            </li>
+          ))}
+        </ol>
+        <div class="flex justify-between mt-5 font-mono text-xs">
+          <span>{prevPart && <a href={`/blog/${prevPart.id}`} class="text-accent no-underline">← Part {prevPart.data.part}</a>}</span>
+          <span>{nextPart && <a href={`/blog/${nextPart.id}`} class="text-accent no-underline">Part {nextPart.data.part} →</a>}</span>
+        </div>
+      </div>
+    </section>
+  )}
 
   {related && (
     <section class="max-w-article mx-auto px-8 pt-6 pb-20">
@@ -257,5 +296,31 @@ const related = others[0] ?? null;
     margin: 40px 0;
     border: 0;
     border-top: 1px solid rgba(255, 255, 255, 0.09);
+  }
+
+  /* Post images (screenshots) */
+  .post-body img {
+    display: block;
+    max-width: 100%;
+    margin: 28px auto 10px;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+  }
+
+  /* Collapsed text alternative for a rendered diagram */
+  .post-body details.diagram-note {
+    margin: -14px 0 28px;
+  }
+  .post-body details.diagram-note summary {
+    cursor: pointer;
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 11.5px;
+    color: #6a7b81;
+  }
+  .post-body details.diagram-note p {
+    margin: 10px 0 0;
+    font-size: 14px;
+    line-height: 1.6;
+    color: #8a989e;
   }
 </style>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,12 +1,10 @@
 ---
 import MainLayout from '../../layouts/MainLayout.astro';
-import { getCollection } from 'astro:content';
+import { getPosts } from '../../lib/blog';
 
 const monthFmt = new Intl.DateTimeFormat('en-US', { month: 'short', year: 'numeric' });
 
-const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
-  (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
-);
+const posts = await getPosts();
 
 // Featured = the flagged post, falling back to the most recent.
 const featured = posts.find((p) => p.data.featured) ?? posts[0];
@@ -36,7 +34,12 @@ const featured = posts.find((p) => p.data.featured) ?? posts[0];
       <a href={`/blog/${featured.id}`} class="no-underline text-text grid grid-cols-1 lg:grid-cols-[1.05fr_0.95fr] gap-9 p-[34px] border border-accent/25 rounded-[18px] bg-panel items-center transition-colors hover:border-accent/50 relative overflow-hidden">
         <div class="absolute inset-0 pointer-events-none" style="background:radial-gradient(500px 260px at 88% 0%,rgba(110,231,199,.1),transparent 70%)"></div>
         <div class="relative">
-          <span class="font-mono text-[11px] text-accent uppercase tracking-[0.16em]">Latest · {featured.data.category}</span>
+          <span class="font-mono text-[11px] text-accent uppercase tracking-[0.16em]">
+            Latest · {featured.data.category}
+            {featured.data.draft && (
+              <span class="ml-3 normal-case tracking-normal text-[10px] text-amber-300 border border-amber-300/40 rounded px-1.5 py-0.5">draft</span>
+            )}
+          </span>
           <h2 class="mt-3.5 mb-0 font-bold text-[clamp(26px,3.2vw,36px)] leading-[1.1] tracking-[-0.02em]">{featured.data.title}</h2>
           <p class="mt-4 text-base leading-[1.6] text-text-3">{featured.data.description}</p>
           <div class="flex items-center gap-3.5 mt-[22px] font-mono text-xs text-text-faint">
@@ -55,10 +58,15 @@ const featured = posts.find((p) => p.data.featured) ?? posts[0];
     {posts.map((post) => (
       <a href={`/blog/${post.id}`} class="no-underline text-text grid grid-cols-1 sm:grid-cols-[130px_1fr_auto] gap-7 sm:items-baseline py-7 border-t border-white/[0.09] last:border-b group">
         <span class="font-mono text-xs leading-[1.4] text-text-faint">
-          {monthFmt.format(post.data.date)}<br /><span class="text-[#4a5a5f]">{post.data.category}</span>
+          {monthFmt.format(post.data.date)}<br /><span class="text-[#4a5a5f]">{post.data.part ? `Part ${post.data.part}` : post.data.category}</span>
         </span>
         <div>
-          <h3 class="m-0 font-semibold text-[22px] leading-tight group-hover:text-accent transition-colors">{post.data.title}</h3>
+          <h3 class="m-0 font-semibold text-[22px] leading-tight group-hover:text-accent transition-colors">
+            {post.data.title}
+            {post.data.draft && (
+              <span class="ml-2.5 align-middle font-mono font-normal text-[10px] text-amber-300 border border-amber-300/40 rounded px-1.5 py-0.5 whitespace-nowrap">draft</span>
+            )}
+          </h3>
           <p class="mt-2 text-[14.5px] leading-[1.55] text-text-3 max-w-[680px]">{post.data.description}</p>
         </div>
         <span class="font-mono text-xs text-text-faint whitespace-nowrap">{post.data.readingTime} →</span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
 import MainLayout from '../layouts/MainLayout.astro';
-import { getCollection } from 'astro:content';
+import { getPosts } from '../lib/blog';
 
 const projects = [
   {
@@ -80,9 +80,7 @@ const featuredBullets = [
 ];
 
 // Two most recent posts for the "From the blog" teasers.
-const posts = (await getCollection('blog', ({ data }) => !data.draft))
-  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
-  .slice(0, 2);
+const posts = (await getPosts()).slice(0, 2);
 
 const eyebrow = 'font-mono text-[13px] font-semibold uppercase tracking-eyebrow text-accent';
 ---


### PR DESCRIPTION
## Summary

Adds Jason's four-part **Building ADO Companion** series to the blog as `draft: true` posts, per the website handoff brief. Prose is untouched (format-level edits only); the drafts render on preview deploys for review and stay hidden from production until each post's `draft` flag is flipped.

## Changes

**Content**
- Replaced the earlier paraphrased ADO Companion post with the canonical Part 1 draft (same slug/URL: `/blog/building-ado-companion`)
- Added Part 2 (`/blog/ado-analytics-odata`), Part 3 (`/blog/ado-ai-copilot-agent`), Part 4 (`/blog/ado-mlflow-tracing`)
- `📸 Screenshot slot` markers preserved as HTML comments — kept in source, invisible in rendered output
- `🖼️ Diagram reading` blockquotes rendered as collapsed `<details>` text alternatives beneath each mermaid diagram (accessible, not visible body text)
- Part 2's two dashboard screenshots reference `/images/blog/ado-companion/` — **PNGs still need to be added** (`analytics-overview-light.png`, `analytics-overview-30d.png`)

**Infrastructure**
- Content schema: new optional `series` and `part` fields
- Draft visibility: drafts are excluded only when `VERCEL_ENV=production`; preview deploys and local builds include them with a visible "draft" badge (new shared helper `src/lib/blog.ts`, used by the blog index, post pages, and homepage teasers)
- Post template: series panel ("Building ADO Companion — 4 parts") with links to all parts plus prev/next navigation; related-post card prefers the next part in the series
- Post styles for real images and the collapsed diagram notes

## Verification

- `VERCEL_ENV=production astro build` → 9 pages, drafts absent from `/blog`
- `VERCEL_ENV=preview astro build` → 13 pages, all four drafts render with series nav, draft badges, hidden screenshot slots, and mermaid diagram blocks

## Note on merging

Merging is safe for production (drafts stay hidden) with one visible effect: the current live ADO Companion post — a paraphrase of Part 1 written during the redesign — is replaced by the canonical draft and therefore **unpublished until Part 1's `draft` flag is flipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQZUT4bCHcfGbR6hYkzvzh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQZUT4bCHcfGbR6hYkzvzh)_