### PR TITLE
Publish all four Building ADO Companion posts

### DIFF
--- a/src/content/blog/ado-ai-copilot-agent.md
+++ b/src/content/blog/ado-ai-copilot-agent.md
@@ -6,7 +6,7 @@ category: "AI agents"
 readingTime: "11 min"
 tags: [databricks, azure-devops, ai-agents, tool-calling, fmapi, genie, fastapi, llm]
 author: "Jason Paladini"
-draft: true
+draft: false
 series: "Building ADO Companion"
 part: 3
 ---

--- a/src/content/blog/ado-analytics-odata.md
+++ b/src/content/blog/ado-analytics-odata.md
@@ -6,13 +6,16 @@ category: "Deep dive"
 readingTime: "10 min"
 tags: [azure-devops, analytics, odata, databricks, genie, dashboards, fastapi]
 author: "Jason Paladini"
-draft: true
+draft: false
 series: "Building ADO Companion"
 part: 2
 ---
 > Part 2 of the **ADO Companion** series. Part 1 covered building and shipping the app on Databricks. This one is about a single, deceptively deep question: **how do you actually pull the data behind a delivery-metrics dashboard?**
 
-![ADO Companion — the Overview analytics dashboard in light mode, showing four KPI cards with sparklines, a pipeline bar chart, a work-items-by-state donut, and a recent-items table](/images/blog/ado-companion/analytics-overview-light.png)
+<!-- swap for real screenshot: ![ADO Companion — the Overview analytics dashboard in light mode, showing four KPI cards with sparklines, a pipeline bar chart, a work-items-by-state donut, and a recent-items table](/images/blog/ado-companion/analytics-overview-light.png) -->
+<figure class="img-placeholder">
+  <span>ADO Companion — the Overview analytics dashboard in light mode, showing four KPI cards with sparklines, a pipeline bar chart, a work-items-by-state donut, and a recent-items table</span>
+</figure>
 
 *The live dashboard. The **work-items-by-state donut** ("25 total") and the **"Open work items"** KPI (14) are **server-side OData aggregates** — `groupby((StateCategory), aggregate($count as Count))` — not a client-side count of fetched rows. The KPI's **sparkline** and its "25 total · 7d" caption come from a **`WorkItemSnapshot`** daily trend over the selected range.*
 
@@ -185,7 +188,10 @@ flowchart LR
   <p>A left-to-right data-flow diagram. On the left, a box "Overview dashboard (React + TanStack Query)" with an arrow labeled "/api/.../analytics?range=" pointing right to a box "FastAPI BFF (Analytics client)." Between the BFF and a blue cylinder labeled "ADO Analytics OData — analytics.dev.azure.com," draw a bold double-headed/round-trip arrow labeled "$apply aggregates + snapshot trends" (request out, aggregated numbers back). Color that cylinder blue = the live path that exists now. Then, from the BFF, a dashed arrow labeled "Phase 3" points down/right to a box "Scheduled Job: OData → Delta," which has a dashed arrow to a purple cylinder "Delta + Genie Space." Finally a dashed arrow labeled "future NL Q&A" goes from the dashboard directly to the Genie cylinder. Visual intent: solid blue = today's live OData aggregation path; dashed purple = the planned lakehouse/Genie extension fed by the same OData source.</p>
 </details>
 
-![The same dashboard with the time range set to 30d — the Open KPI caption now reads "25 total · 30d" and the sparkline shows the longer trend window](/images/blog/ado-companion/analytics-overview-30d.png)
+<!-- swap for real screenshot: ![The same dashboard with the time range set to 30d — the Open KPI caption now reads "25 total · 30d" and the sparkline shows the longer trend window](/images/blog/ado-companion/analytics-overview-30d.png) -->
+<figure class="img-placeholder">
+  <span>The same dashboard with the time range set to 30d — the Open KPI caption now reads "25 total · 30d" and the sparkline shows the longer trend window</span>
+</figure>
 
 *The payoff: switching the range to **30d** refetches the OData snapshot window. The KPI caption becomes **"25 total · 30d"** and the sparkline redraws over the longer trend. The 24h / 7d / 30d control is now **real**, not decorative — it sets the `DateValue` window on the `WorkItemSnapshot` query.*
 

--- a/src/content/blog/ado-mlflow-tracing.md
+++ b/src/content/blog/ado-mlflow-tracing.md
@@ -6,7 +6,7 @@ category: "Observability"
 readingTime: "9 min"
 tags: [databricks, mlflow, tracing, observability, ai-agents, llmops, fmapi]
 author: "Jason Paladini"
-draft: true
+draft: false
 series: "Building ADO Companion"
 part: 4
 ---

--- a/src/content/blog/building-ado-companion.md
+++ b/src/content/blog/building-ado-companion.md
@@ -6,7 +6,7 @@ category: "Case study"
 readingTime: "15 min"
 tags: [databricks, azure-devops, react, fastapi, ci-cd, devops, asset-bundles, claude-code]
 author: "Jason Paladini"
-draft: true
+draft: false
 series: "Building ADO Companion"
 part: 1
 ---


### PR DESCRIPTION
## Summary

Follow-up to #22, which was merged just before the publish commit landed on the branch — so `main` still has the series as `draft: true` and production hides it. This PR carries only that final commit:

- Flip `draft: false` on all four "Building ADO Companion" posts
- Render Part 2's two pending dashboard screenshots as styled placeholder figures until the PNGs are provided (real image refs preserved in HTML comments for the swap)

Verified locally: `VERCEL_ENV=production astro build` → 13 pages, all four posts present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQZUT4bCHcfGbR6hYkzvzh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQZUT4bCHcfGbR6hYkzvzh)_