### PR TITLE
Feature the ADO Companion series and refresh the earlier posts

### DIFF
--- a/src/content/blog/building-ado-companion.md
+++ b/src/content/blog/building-ado-companion.md
@@ -7,6 +7,7 @@ readingTime: "15 min"
 tags: [databricks, azure-devops, react, fastapi, ci-cd, devops, asset-bundles, claude-code]
 author: "Jason Paladini"
 draft: false
+featured: true
 series: "Building ADO Companion"
 part: 1
 ---

--- a/src/content/blog/call-intelligence-lakehouse.md
+++ b/src/content/blog/call-intelligence-lakehouse.md
@@ -10,6 +10,16 @@ author: "Jason Paladini"
 
 Customer-service calls are one of the richest, least-used datasets a company has. The recordings exist; almost nothing reads them at scale. I built a lakehouse pipeline that ingests, transcribes, analyzes and semantically searches those calls — and a RAG agent on top that answers investigative questions *with citations*, so an analyst can trust the answer enough to act on it.
 
+---
+
+## TL;DR
+
+- **A medallion layout keeps an AI pipeline debuggable.** Transcription, analysis, and embeddings are each a tracked step — when a transcript looks wrong, you walk back one layer, not one opaque job.
+- **Two indexes, not one.** A transcript index answers "what was said"; an analysis index answers "what did we already conclude." The agent retrieves against both and fuses at query time.
+- **Citations are the contract.** Every claim points to a transcript span it can be checked against — and an MLflow eval stack (schema checks, LLM-as-judge, A/B) turns prompt changes into defensible numbers.
+
+---
+
 ## Medallion, end to end
 
 The backbone is a standard Bronze/Silver/Gold layout, which matters more than it sounds — it's what keeps a messy, multi-step AI pipeline debuggable.
@@ -24,16 +34,52 @@ The backbone is a standard Bronze/Silver/Gold layout, which matters more than it
 
 Because every transformation is its own layer, when a transcript looks wrong I can walk back exactly one step at a time instead of re-running an opaque end-to-end job.
 
+---
+
 ## Why two indexes
 
 A single vector index over transcripts answers "what was said." But investigators also ask "what did we already conclude?" — questions better served by the prior LLM analyses. So the agent retrieves against both: a transcript index for ground truth, and an analysis index for prior reasoning. The two are fused at query time.
+
+```mermaid
+flowchart LR
+  Q([Analyst question]) --> AG[RAG agent]
+  AG == "what was said" ==> TI[(Transcript index<br/>ground truth)]
+  AG == "what we concluded" ==> AI[(Analysis index<br/>prior reasoning)]
+  TI --> F[Fuse at query time]
+  AI --> F
+  F --> ANS[Answer with citations<br/>every claim → transcript span]
+
+  classDef idx fill:#E7EEFC,stroke:#2D6CDF,color:#15191E;
+  classDef out fill:#E4F3EA,stroke:#138A4E,color:#15191E;
+  class TI,AI idx;
+  class ANS out;
+```
+
+<details class="diagram-note">
+  <summary>Diagram description (text version)</summary>
+  <p>A left-to-right retrieval diagram. An "Analyst question" node flows into a "RAG agent" box. From the agent, two bold arrows fan out to two blue cylinders: a "Transcript index — ground truth" (labeled "what was said") and an "Analysis index — prior reasoning" (labeled "what we concluded"). Both cylinders feed a "Fuse at query time" box, which flows into a green "Answer with citations" node annotated "every claim → transcript span". The message: one question, two retrieval planes, one cited answer.</p>
+</details>
 
 > A citation isn't decoration. It's the contract: every claim the agent makes points back to a specific transcript span it can be checked against.
 
 Grounding with citations is what makes this usable for high-trust work. The agent doesn't get to assert; it gets to quote. If it can't find support, that's a visible gap rather than a confident hallucination.
 
+---
+
 ## Measuring it like a pipeline
 
-None of this ships without evaluation. I run an MLflow-based framework with three layers: deterministic schema checks (did the output even conform?), LLM-as-judge scoring for quality, and A/B comparison across prompts and models. That turns "the new prompt feels better" into a number I can defend — and the prompts themselves come from the [control plane](/blog/prompt-control-plane), so every eval run is tied to an exact version.
+None of this ships without evaluation. I run an MLflow-based framework with three layers:
+
+| Layer | Question it answers | Failure it catches |
+|---|---|---|
+| Deterministic schema checks | Did the output even conform? | Malformed or incomplete responses |
+| LLM-as-judge scoring | Is the answer good? | Quality drift, weak grounding |
+| A/B across prompts and models | Is the new version *better*? | "Feels better" shipping on vibes |
+
+That turns "the new prompt feels better" into a number I can defend — and the prompts themselves come from the [control plane](/blog/prompt-control-plane), so every eval run is tied to an exact version.
 
 The result is a system that reads thousands of calls nobody had time to listen to, and answers questions about them in a way you can actually audit. That combination — scale plus trust — is the whole point.
+
+---
+
+*The prompts behind every step here are versioned rows in [the prompt control plane](/blog/prompt-control-plane) — same lakehouse, same governance, one audit trail from wording to answer.*

--- a/src/content/blog/prompt-control-plane.md
+++ b/src/content/blog/prompt-control-plane.md
@@ -6,10 +6,19 @@ category: "Architecture"
 readingTime: "8 min"
 tags: ["GenAI", "Architecture", "Governance"]
 author: "Jason Paladini"
-featured: true
 ---
 
 When you run GenAI in an enterprise, the bottleneck stops being the model and starts being the *process*. A new workflow shouldn't require a release. So at Horizon I built a prompt control plane: every prompt, model binding, and routing rule lives in a database table, and shipping a new LLM workflow is a data change — not a code change.
+
+---
+
+## TL;DR
+
+- **Prompts change on a different rhythm than code** — domain experts want to iterate Tuesday afternoon, not at the next deploy window. Putting prompts in git makes engineers the reviewers of wording they aren't qualified to review.
+- **The control plane is a table.** A workflow row points at a versioned prompt, a model, and a stage. Promotion to production is a one-column update; rollback is the same update in reverse.
+- **Audit comes for free.** Every run resolves and logs its exact prompt version and model, so "which prompt produced this output, months ago?" is a query, not an archaeology project.
+
+---
 
 ## The problem with prompts in code
 
@@ -19,7 +28,34 @@ The deeper issue is auditability. In a regulated environment you need to answer 
 
 > Treat prompts as governed data, not as source code. Then versioning, promotion, and audit come for free from the database you already trust.
 
+---
+
 ## The control plane, concretely
+
+The lifecycle of a prompt, end to end:
+
+```mermaid
+flowchart LR
+  SME[Domain expert<br/>edits prompt] --> V[New prompt version<br/>v8 · staging row]
+  V -->|review + eval| P{Promote?}
+  P -- yes --> S[UPDATE stage = 'prod'<br/>one column]
+  P -- no --> V
+  S --> APP[App resolves<br/>workflow + stage at runtime]
+  APP --> LOG[(Run log:<br/>exact version + model)]
+  S -. rollback = same UPDATE,<br/>previous version .-> V
+
+  classDef edit fill:#EFEAFE,stroke:#7A5AF8,color:#15191E;
+  classDef gate fill:#FFF6E5,stroke:#B7791F,color:#15191E;
+  classDef live fill:#E4F3EA,stroke:#138A4E,color:#15191E;
+  class SME,V edit;
+  class P gate;
+  class S,APP,LOG live;
+```
+
+<details class="diagram-note">
+  <summary>Diagram description (text version)</summary>
+  <p>A left-to-right lifecycle diagram. A "Domain expert edits prompt" box flows into a "New prompt version — v8, staging row" box. An arrow labeled "review + eval" leads to a "Promote?" decision diamond. The "yes" branch goes to "UPDATE stage = 'prod' — one column", then to "App resolves workflow + stage at runtime", ending at a cylinder "Run log: exact version + model". The "no" branch loops back to the staging version, and a dashed arrow from the promote step back to the version box notes that rollback is the same UPDATE pointing at the previous version. Purple = editing, amber = the promotion gate, green = the live path.</p>
+</details>
 
 A workflow is a row. It points at a versioned prompt, a model, and an environment. Promotion to production is an update to a single column — and because it's a table, the whole thing is queryable, diff-able, and protected by the same access controls as the rest of the lakehouse.
 
@@ -34,8 +70,14 @@ escalation_rag   v12              gpt-4o            <span style="color:#8af0d6">
 
 The application never hardcodes a prompt. At runtime it resolves `(workflow, stage)` to the active version and logs exactly what it used. Rolling back a bad prompt is flipping `stage` back to the previous version — no rebuild, no redeploy.
 
+---
+
 ## What it changed
 
 Two things. First, the people closest to the domain can iterate on prompts safely, with staging and a real promotion path — and I review the diff like any other data product PR. Second, every output is traceable to an exact prompt version and model, which is the difference between "the AI said so" and an answer you can stand behind in an investigation.
 
 It's not glamorous. It's a table. But putting the control surface in the database — where governance, access control and lineage already live — is what made GenAI shippable on our terms.
+
+---
+
+*The eval framework that scores these prompts before promotion is covered in [the call intelligence write-up](/blog/call-intelligence-lakehouse) — the two systems share a rule: nothing reaches prod on vibes.*

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -35,7 +35,7 @@ const featured = posts.find((p) => p.data.featured) ?? posts[0];
         <div class="absolute inset-0 pointer-events-none" style="background:radial-gradient(500px 260px at 88% 0%,rgba(110,231,199,.1),transparent 70%)"></div>
         <div class="relative">
           <span class="font-mono text-[11px] text-accent uppercase tracking-[0.16em]">
-            Latest · {featured.data.category}
+            Featured · {featured.data.category}
             {featured.data.draft && (
               <span class="ml-3 normal-case tracking-normal text-[10px] text-amber-300 border border-amber-300/40 rounded px-1.5 py-0.5">draft</span>
             )}


### PR DESCRIPTION
## Summary

- Move the `featured` flag from the "prompt control plane" sample post to Part 1 of the Building ADO Companion series, so the series owns the big card on `/blog`; the card label now reads "Featured" instead of "Latest" (accurate when the featured post isn't the newest)
- Bring the two earlier posts in line with the series format, keeping their prose: TL;DR sections, `---` separators, a mermaid diagram each (prompt lifecycle; dual-index retrieval path) with collapsed text alternatives, an eval-layers table, and closing cross-link lines

Verified with a production-mode build (13 pages, no errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQZUT4bCHcfGbR6hYkzvzh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQZUT4bCHcfGbR6hYkzvzh)_